### PR TITLE
[codex] Fix mutual information formatting

### DIFF
--- a/09-Information-Theory/03-Mutual-Information/exercises.ipynb
+++ b/09-Information-Theory/03-Mutual-Information/exercises.ipynb
@@ -1,652 +1,276 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Mutual Information -- Exercises\n",
-    "\n",
-    "8 exercises covering mutual information from first-principles tabular calculations to contrastive learning and active learning.\n",
-    "\n",
-    "| Difficulty | Exercises | Focus |\n",
-    "| --- | --- | --- |\n",
-    "| ★ | 1-3 | definitions, exact computation, structural identities |\n",
-    "| ★★ | 4-6 | chain rules, channel calculations, estimation |\n",
-    "| ★★★ | 7-8 | InfoNCE and modern ML applications |\n",
-    "\n",
-    "Each exercise has three cells:\n",
-    "\n",
-    "- **Problem** -- the task statement\n",
-    "- **Your Solution** -- a runnable scaffold\n",
-    "- **Solution** -- a complete reference implementation with checks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "ename": "SyntaxError",
-     "evalue": "unterminated string literal (detected at line 14) (296096068.py, line 14)",
-     "output_type": "error",
-     "traceback": [
-      "  \u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 14\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mprint('\u001b[39m\n          ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m unterminated string literal (detected at line 14)\n"
-     ]
+      "cell_type": "markdown",
+      "id": "88274d32",
+      "metadata": {},
+      "source": [
+        "# Mutual Information -- Exercises\n\n8 exercises covering mutual information from first-principles tabular calculations to contrastive learning and active learning.\n\n| Difficulty | Exercises | Focus |\n| --- | --- | --- |\n| ★ | 1-3 | definitions, exact computation, structural identities |\n| ★★ | 4-6 | chain rules, channel calculations, estimation |\n| ★★★ | 7-8 | InfoNCE and modern ML applications |\n\nEach exercise has three cells:\n\n- **Problem** -- the task statement\n- **Your Solution** -- a runnable scaffold\n- **Solution** -- a complete reference implementation with checks"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "ca0ef447",
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "SyntaxError",
+          "evalue": "unterminated string literal (detected at line 14) (296096068.py, line 14)",
+          "output_type": "error",
+          "traceback": [
+            "  \u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 14\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mprint('\u001b[39m\n          ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m unterminated string literal (detected at line 14)\n"
+          ]
+        }
+      ],
+      "source": [
+        "import numpy as np\nimport numpy.linalg as la\n\ntry:\n    import matplotlib.pyplot as plt\n    HAS_MPL = True\nexcept ImportError:\n    HAS_MPL = False\n\nnp.set_printoptions(precision=6, suppress=True)\nnp.random.seed(42)\n\ndef header(title):\n    print('\\\\n' + '=' * len(title))\n    print(title)\n    print('=' * len(title))\n\ndef check_close(name, got, expected, tol=1e-8):\n    ok = np.allclose(got, expected, atol=tol, rtol=tol)\n    print(f\"{'PASS' if ok else 'FAIL'} — {name}\")\n    if not ok:\n        print('  expected:', expected)\n        print('  got     :', got)\n    return ok\n\ndef check_true(name, cond):\n    print(f\"{'PASS' if cond else 'FAIL'} — {name}\")\n    return cond\n\ndef entropy(p):\n    p = np.asarray(p, dtype=float)\n    p = p[p > 0]\n    return -np.sum(p * np.log(p))\n\ndef mutual_info_from_joint(P):\n    P = np.asarray(P, dtype=float)\n    px = P.sum(axis=1, keepdims=True)\n    py = P.sum(axis=0, keepdims=True)\n    with np.errstate(divide='ignore', invalid='ignore'):\n        ratio = np.where(P > 0, P / (px @ py), 1.0)\n        terms = np.where(P > 0, P * np.log(ratio), 0.0)\n    return float(np.sum(terms))\n\ndef conditional_mi_from_joint_xyz(Pxyz):\n    Pxyz = np.asarray(Pxyz, dtype=float)\n    Pz = Pxyz.sum(axis=(0, 1), keepdims=True)\n    Pxz = Pxyz.sum(axis=1, keepdims=True)\n    Pyz = Pxyz.sum(axis=0, keepdims=True)\n    with np.errstate(divide='ignore', invalid='ignore'):\n        num = Pxyz * Pz\n        den = Pxz * Pyz\n        ratio = np.where(Pxyz > 0, num / den, 1.0)\n        terms = np.where(Pxyz > 0, Pxyz * np.log(ratio), 0.0)\n    return float(np.sum(terms))\n\ndef histogram_mi(x, y, bins=20):\n    hist, _, _ = np.histogram2d(x, y, bins=bins)\n    P = hist / hist.sum()\n    return mutual_info_from_joint(P)\n\ndef binary_entropy(p):\n    p = np.clip(np.asarray(p, dtype=float), 1e-12, 1 - 1e-12)\n    return -(p * np.log(p) + (1 - p) * np.log(1 - p))\n\nprint('Setup complete.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "144f76da",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 1 ★ -- Tabular Mutual Information\n\nFor the joint table\n\n$$P_{XY} = \\begin{bmatrix}0.40 & 0.10 \\ 0.10 & 0.40\\end{bmatrix},$$\n\n**(a)** compute $I(X;Y)$ directly.\n\n**(b)** verify symmetry by comparing with $I(Y;X)$.\n\n**(c)** verify the entropy identity $I(X;Y)=H(X)+H(Y)-H(X,Y)$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5fb756de",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 1: Your Solution\nP = np.array([[0.40, 0.10],\n              [0.10, 0.40]])\n\nmi_xy = None  # YOUR CODE HERE\nmi_yx = None  # YOUR CODE HERE\nhx = None     # YOUR CODE HERE\nhy = None     # YOUR CODE HERE\nhxy = None    # YOUR CODE HERE\n\nprint('mi_xy =', mi_xy)\nprint('mi_yx =', mi_yx)\nprint('hx, hy, hxy =', hx, hy, hxy)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "918b5a1c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 1: Solution\nP = np.array([[0.40, 0.10],\n              [0.10, 0.40]])\nmi_xy = mutual_info_from_joint(P)\nmi_yx = mutual_info_from_joint(P.T)\nhx = entropy(P.sum(axis=1))\nhy = entropy(P.sum(axis=0))\nhxy = entropy(P.ravel())\n\nheader('Exercise 1: Tabular Mutual Information')\nprint(f'I(X;Y) = {mi_xy:.6f}')\nprint(f'I(Y;X) = {mi_yx:.6f}')\nprint(f'H(X)+H(Y)-H(X,Y) = {hx + hy - hxy:.6f}')\ncheck_close('symmetry', mi_xy, mi_yx)\ncheck_close('entropy identity', mi_xy, hx + hy - hxy)\nprint('\\\\nTakeaway: mutual information can be computed exactly from a joint table and is symmetric.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "03a48686",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 2 ★ -- Zero Correlation, Positive Mutual Information\n\nLet $X \\sim \\mathcal{N}(0,1)$ and $Y = X^2 + 0.1\\varepsilon$ with independent Gaussian noise.\n\n**(a)** estimate the correlation between $X$ and $Y$.\n\n**(b)** estimate the mutual information using a simple histogram estimator.\n\n**(c)** explain why the two quantities tell different stories."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a7c5c1ee",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 2: Your Solution\nnp.random.seed(42)\nN = 5000\nX = np.random.randn(N)\nY = X**2 + 0.1 * np.random.randn(N)\n\ncorr = None  # YOUR CODE HERE\nmi_est = None  # YOUR CODE HERE\n\nprint('corr =', corr)\nprint('mi_est =', mi_est)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b39ad552",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 2: Solution\nnp.random.seed(42)\nN = 5000\nX = np.random.randn(N)\nY = X**2 + 0.1 * np.random.randn(N)\n\ncorr = np.corrcoef(X, Y)[0, 1]\nmi_est = histogram_mi(X, Y, bins=30)\n\nheader('Exercise 2: Zero Correlation, Positive MI')\nprint(f'Correlation estimate: {corr:.6f}')\nprint(f'Histogram MI estimate: {mi_est:.6f}')\ncheck_true('correlation is small in magnitude', abs(corr) < 0.1)\ncheck_true('mutual information is positive', mi_est > 0.2)\nprint('\\\\nTakeaway: correlation can miss nonlinear dependence, but mutual information still detects it.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2a5c490b",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 3 ★ -- Mutual Information as KL Divergence\n\nFor the same table as Exercise 1, compute\n\n$$D_{\\mathrm{KL}}(P_{XY} \\| P_X P_Y)$$\n\nand verify that it equals mutual information.\n\nAlso check that if the joint table factorizes exactly, the mutual information is zero."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6f68b0a8",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 3: Your Solution\nP = np.array([[0.40, 0.10],\n              [0.10, 0.40]])\n\nproduct = None  # YOUR CODE HERE\nkl_val = None   # YOUR CODE HERE\nmi_val = None   # YOUR CODE HERE\n\nP_ind = np.outer(np.array([0.5, 0.5]), np.array([0.6, 0.4]))\nmi_ind = None   # YOUR CODE HERE\n\nprint('kl_val =', kl_val)\nprint('mi_val =', mi_val)\nprint('mi_ind =', mi_ind)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "31ef1bd1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 3: Solution\nP = np.array([[0.40, 0.10],\n              [0.10, 0.40]])\nproduct = np.outer(P.sum(axis=1), P.sum(axis=0))\nkl_val = np.sum(np.where(P > 0, P * np.log(P / product), 0.0))\nmi_val = mutual_info_from_joint(P)\n\nP_ind = np.outer(np.array([0.5, 0.5]), np.array([0.6, 0.4]))\nmi_ind = mutual_info_from_joint(P_ind)\n\nheader('Exercise 3: MI as KL Divergence')\nprint(f'KL(P_xy || P_x P_y) = {kl_val:.6f}')\nprint(f'I(X;Y)              = {mi_val:.6f}')\nprint(f'I(X;Y) for independent table = {mi_ind:.6f}')\ncheck_close('MI equals KL to independence', mi_val, kl_val)\ncheck_close('independent table has zero MI', mi_ind, 0.0)\nprint('\\\\nTakeaway: mutual information is exactly the KL divergence from the true joint law to the independence model.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "af5922af",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 4 ★★ -- Chain Rule and Conditional Mutual Information\n\nConstruct a three-variable discrete system and verify\n\n$$I(X,Z;Y) = I(X;Y) + I(Z;Y \\mid X).$$\n\nUse the synthetic model from the theory notebook:\n$X, Z \\sim \\operatorname{Bern}(1/2)$ independently and\n$Y = (X + Z + N) \\bmod 2$ with $N \\sim \\operatorname{Bern}(0.2)$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d0c45a20",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 4: Your Solution\nnp.random.seed(11)\nN = 200000\nX = np.random.binomial(1, 0.5, size=N)\nZ = np.random.binomial(1, 0.5, size=N)\nY = (X + Z + np.random.binomial(1, 0.2, size=N)) % 2\n\n# Build joint table and compute both sides of the identity.\nlhs = None  # YOUR CODE HERE\nrhs = None  # YOUR CODE HERE\n\nprint('lhs =', lhs)\nprint('rhs =', rhs)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c51b09e9",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 4: Solution\nnp.random.seed(11)\nN = 200000\nX = np.random.binomial(1, 0.5, size=N)\nZ = np.random.binomial(1, 0.5, size=N)\nY = (X + Z + np.random.binomial(1, 0.2, size=N)) % 2\n\nPxyz = np.zeros((2, 2, 2), dtype=float)\nfor x, z, y in zip(X, Z, Y):\n    Pxyz[x, z, y] += 1\nPxyz /= N\n\nlhs = mutual_info_from_joint(Pxyz.reshape(4, 2))\nrhs = mutual_info_from_joint(Pxyz.sum(axis=1)) + conditional_mi_from_joint_xyz(np.transpose(Pxyz, (1, 2, 0)))\n\nheader('Exercise 4: Chain Rule')\nprint(f'I((X,Z);Y)      = {lhs:.6f}')\nprint(f'I(X;Y)+I(Z;Y|X) = {rhs:.6f}')\ncheck_close('chain rule', lhs, rhs, tol=2e-3)\nprint('\\\\nTakeaway: chain rules decompose information into what is already explained and what is added conditionally.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "99a12e9d",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 5 ★★ -- Binary Symmetric Channel and Capacity\n\nFor a binary symmetric channel with flip probability $\\epsilon$ and a uniform input,\n\n$$I(X;Y) = \\log 2 - h_2(\\epsilon)$$\n\nin nats.\n\n**(a)** compute the mutual information at $\\epsilon = 0.1, 0.25, 0.49$.\n\n**(b)** verify that the mutual information decreases as noise increases."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f468d731",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 5: Your Solution\nepsilons = np.array([0.10, 0.25, 0.49])\nmi_vals = None  # YOUR CODE HERE\n\nprint('mi_vals =', mi_vals)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "80e21f9d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 5: Solution\nepsilons = np.array([0.10, 0.25, 0.49])\nmi_vals = np.log(2) - binary_entropy(epsilons)\n\nheader('Exercise 5: Binary Symmetric Channel')\nfor e, m in zip(epsilons, mi_vals):\n    print(f'epsilon={e:.2f} -> I(X;Y)={m:.6f} nats')\ncheck_true('mutual information decreases with noise', np.all(np.diff(mi_vals) < 0))\nprint('\\\\nTakeaway: channel noise destroys information, and capacity falls accordingly.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fe8def8b",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 6 ★★ -- Estimator Bias in Practice\n\nEstimate mutual information for a correlated Gaussian pair with a simple histogram estimator.\nUse $\nho = 0.6$ and compare the estimate with the exact Gaussian formula\n\n$$I(X;Y) = -\tfrac12 \\log(1-\nho^2).$$\n\nRepeat for two different bin counts and interpret the difference."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "69f06173",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 6: Your Solution\nnp.random.seed(5)\nrho = 0.6\ncov = np.array([[1.0, rho], [rho, 1.0]])\nXY = np.random.multivariate_normal([0.0, 0.0], cov, size=4000)\ntrue_mi = None  # YOUR CODE HERE\nest_12 = None   # YOUR CODE HERE\nest_30 = None   # YOUR CODE HERE\n\nprint(true_mi, est_12, est_30)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e5dbe433",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 6: Solution\nnp.random.seed(5)\nrho = 0.6\ncov = np.array([[1.0, rho], [rho, 1.0]])\nXY = np.random.multivariate_normal([0.0, 0.0], cov, size=4000)\ntrue_mi = -0.5 * np.log(1 - rho**2)\nest_12 = histogram_mi(XY[:, 0], XY[:, 1], bins=12)\nest_30 = histogram_mi(XY[:, 0], XY[:, 1], bins=30)\n\nheader('Exercise 6: Estimator Bias')\nprint(f'True Gaussian MI   = {true_mi:.6f}')\nprint(f'Histogram estimate (12 bins) = {est_12:.6f}')\nprint(f'Histogram estimate (30 bins) = {est_30:.6f}')\ncheck_true('estimates are positive', est_12 > 0 and est_30 > 0)\ncheck_true('different bin counts give different estimates', abs(est_12 - est_30) > 1e-3)\nprint('\\\\nTakeaway: mutual-information estimation is sensitive to estimator design even on simple continuous problems.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "26fe7834",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 7 ★★★ -- InfoNCE as a Lower-Bound-Style Objective\n\nUse correlated Gaussian views $Z_1, Z_2$ with correlation $\nho = 0.8$.\nCompute an InfoNCE-style lower bound with $K=8$ and $K=64$ negatives and compare with the exact Gaussian MI.\n\nYou do not need to prove the bound here; focus on the computation and interpretation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e9a31a32",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 7: Your Solution\nnp.random.seed(123)\nN = 3000\nrho = 0.8\nz1 = np.random.randn(N, 1)\nz2 = rho * z1 + np.sqrt(1 - rho**2) * np.random.randn(N, 1)\n\n# Define a helper and compare K=8 vs K=64.\ndef infonce_bound(K, temperature=0.2):\n    return None  # YOUR CODE HERE\n\nbound_8 = infonce_bound(8)\nbound_64 = infonce_bound(64)\ntrue_mi = None  # YOUR CODE HERE\n\nprint(bound_8, bound_64, true_mi)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cafd497f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 7: Solution\nnp.random.seed(123)\nN = 3000\nrho = 0.8\nz1 = np.random.randn(N, 1)\nz2 = rho * z1 + np.sqrt(1 - rho**2) * np.random.randn(N, 1)\n\ndef infonce_bound(K, temperature=0.2):\n    idx = np.random.choice(N, size=400, replace=False)\n    x = z1[idx]\n    y_pos = z2[idx]\n    pos = (x * y_pos)[:, 0] / temperature\n    losses = []\n    for i, score in enumerate(pos):\n        neg_idx = np.random.choice(N, size=K - 1, replace=False)\n        neg = (x[i] * z2[neg_idx]).reshape(-1) / temperature\n        all_scores = np.concatenate([[score], neg])\n        losses.append(-score + np.log(np.sum(np.exp(all_scores))))\n    return np.log(K) - np.mean(losses)\n\nbound_8 = infonce_bound(8)\nbound_64 = infonce_bound(64)\ntrue_mi = -0.5 * np.log(1 - rho**2)\n\nheader('Exercise 7: InfoNCE Lower Bound')\nprint(f'Bound with K=8:   {bound_8:.6f}')\nprint(f'Bound with K=64:  {bound_64:.6f}')\nprint(f'True Gaussian MI: {true_mi:.6f}')\ncheck_true('bounds are below the true MI up to small estimator noise', bound_8 <= true_mi + 0.5 and bound_64 <= true_mi + 0.5)\ncheck_true('more negatives usually tighten the bound', bound_64 >= bound_8 - 1e-6)\nprint('\\\\nTakeaway: InfoNCE behaves like a practical lower-bound objective, not the mutual information itself.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "775e5762",
+      "metadata": {},
+      "source": [
+        "---\n\n## Exercise 8 ★★★ -- Active Learning via Mutual Information\n\nSuppose the model state $\\Theta \\in \\{0,1\\}$ is equally likely a priori. For a candidate input $x$, the unknown label $Y$ is Bernoulli with parameter:\n\n- $P(Y=1 \\mid \\Theta=0, x)$\n- $P(Y=1 \\mid \\Theta=1, x)$\n\nCompute the BALD-style score $I(Y;\\Theta \\mid x)$ for three candidates and choose the best one.\n\nCandidates:\n\n- uninformative: $(0.50, 0.50)$\n- moderate: $(0.75, 0.25)$\n- very informative: $(0.95, 0.05)$"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "99a9d3bf",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 8: Your Solution\ncandidates = {\n    'uninformative': (0.50, 0.50),\n    'moderate': (0.75, 0.25),\n    'very informative': (0.95, 0.05),\n}\n\ndef bald_score(p0, p1):\n    return None  # YOUR CODE HERE\n\nscores = {name: bald_score(*vals) for name, vals in candidates.items()}\nprint(scores)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c15f54a0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise 8: Solution\ncandidates = {\n    'uninformative': (0.50, 0.50),\n    'moderate': (0.75, 0.25),\n    'very informative': (0.95, 0.05),\n}\n\ndef bald_score(p0, p1):\n    p_theta = np.array([0.5, 0.5])\n    p_y1 = np.dot(p_theta, [p0, p1])\n    H_y = binary_entropy(p_y1)\n    H_y_given_theta = 0.5 * binary_entropy(p0) + 0.5 * binary_entropy(p1)\n    return H_y - H_y_given_theta\n\nscores = {name: bald_score(*vals) for name, vals in candidates.items()}\nbest = max(scores, key=scores.get)\n\nheader('Exercise 8: Active Learning via Mutual Information')\nfor name, score in scores.items():\n    print(f'{name:>16}: {score:.6f} nats')\nprint(f'Best query: {best}')\ncheck_true('the most separated candidate is most informative', best == 'very informative')\ncheck_true('uninformative query has zero information gain', abs(scores['uninformative']) < 1e-10)\nprint('\\\\nTakeaway: active learning prefers queries whose labels would most reduce uncertainty about the model state.')"
+      ]
     }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "import numpy.linalg as la\n",
-    "\n",
-    "try:\n",
-    "    import matplotlib.pyplot as plt\n",
-    "    HAS_MPL = True\n",
-    "except ImportError:\n",
-    "    HAS_MPL = False\n",
-    "\n",
-    "np.set_printoptions(precision=6, suppress=True)\n",
-    "np.random.seed(42)\n",
-    "\n",
-    "def header(title):\n",
-    "    print('\n",
-    "' + '=' * len(title))\n",
-    "    print(title)\n",
-    "    print('=' * len(title))\n",
-    "\n",
-    "def check_close(name, got, expected, tol=1e-8):\n",
-    "    ok = np.allclose(got, expected, atol=tol, rtol=tol)\n",
-    "    print(f\"{'PASS' if ok else 'FAIL'} — {name}\")\n",
-    "    if not ok:\n",
-    "        print('  expected:', expected)\n",
-    "        print('  got     :', got)\n",
-    "    return ok\n",
-    "\n",
-    "def check_true(name, cond):\n",
-    "    print(f\"{'PASS' if cond else 'FAIL'} — {name}\")\n",
-    "    return cond\n",
-    "\n",
-    "def entropy(p):\n",
-    "    p = np.asarray(p, dtype=float)\n",
-    "    p = p[p > 0]\n",
-    "    return -np.sum(p * np.log(p))\n",
-    "\n",
-    "def mutual_info_from_joint(P):\n",
-    "    P = np.asarray(P, dtype=float)\n",
-    "    px = P.sum(axis=1, keepdims=True)\n",
-    "    py = P.sum(axis=0, keepdims=True)\n",
-    "    with np.errstate(divide='ignore', invalid='ignore'):\n",
-    "        ratio = np.where(P > 0, P / (px @ py), 1.0)\n",
-    "        terms = np.where(P > 0, P * np.log(ratio), 0.0)\n",
-    "    return float(np.sum(terms))\n",
-    "\n",
-    "def conditional_mi_from_joint_xyz(Pxyz):\n",
-    "    Pxyz = np.asarray(Pxyz, dtype=float)\n",
-    "    Pz = Pxyz.sum(axis=(0, 1), keepdims=True)\n",
-    "    Pxz = Pxyz.sum(axis=1, keepdims=True)\n",
-    "    Pyz = Pxyz.sum(axis=0, keepdims=True)\n",
-    "    with np.errstate(divide='ignore', invalid='ignore'):\n",
-    "        num = Pxyz * Pz\n",
-    "        den = Pxz * Pyz\n",
-    "        ratio = np.where(Pxyz > 0, num / den, 1.0)\n",
-    "        terms = np.where(Pxyz > 0, Pxyz * np.log(ratio), 0.0)\n",
-    "    return float(np.sum(terms))\n",
-    "\n",
-    "def histogram_mi(x, y, bins=20):\n",
-    "    hist, _, _ = np.histogram2d(x, y, bins=bins)\n",
-    "    P = hist / hist.sum()\n",
-    "    return mutual_info_from_joint(P)\n",
-    "\n",
-    "def binary_entropy(p):\n",
-    "    p = np.clip(np.asarray(p, dtype=float), 1e-12, 1 - 1e-12)\n",
-    "    return -(p * np.log(p) + (1 - p) * np.log(1 - p))\n",
-    "\n",
-    "print('Setup complete.')"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 1 ★ -- Tabular Mutual Information\n",
-    "\n",
-    "For the joint table\n",
-    "\n",
-    "$$P_{XY} = \begin{bmatrix}0.40 & 0.10 \\ 0.10 & 0.40\\end{bmatrix},$$\n",
-    "\n",
-    "**(a)** compute $I(X;Y)$ directly.\n",
-    "\n",
-    "**(b)** verify symmetry by comparing with $I(Y;X)$.\n",
-    "\n",
-    "**(c)** verify the entropy identity $I(X;Y)=H(X)+H(Y)-H(X,Y)$."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 1: Your Solution\n",
-    "P = np.array([[0.40, 0.10],\n",
-    "              [0.10, 0.40]])\n",
-    "\n",
-    "mi_xy = None  # YOUR CODE HERE\n",
-    "mi_yx = None  # YOUR CODE HERE\n",
-    "hx = None     # YOUR CODE HERE\n",
-    "hy = None     # YOUR CODE HERE\n",
-    "hxy = None    # YOUR CODE HERE\n",
-    "\n",
-    "print('mi_xy =', mi_xy)\n",
-    "print('mi_yx =', mi_yx)\n",
-    "print('hx, hy, hxy =', hx, hy, hxy)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 1: Solution\n",
-    "P = np.array([[0.40, 0.10],\n",
-    "              [0.10, 0.40]])\n",
-    "mi_xy = mutual_info_from_joint(P)\n",
-    "mi_yx = mutual_info_from_joint(P.T)\n",
-    "hx = entropy(P.sum(axis=1))\n",
-    "hy = entropy(P.sum(axis=0))\n",
-    "hxy = entropy(P.ravel())\n",
-    "\n",
-    "header('Exercise 1: Tabular Mutual Information')\n",
-    "print(f'I(X;Y) = {mi_xy:.6f}')\n",
-    "print(f'I(Y;X) = {mi_yx:.6f}')\n",
-    "print(f'H(X)+H(Y)-H(X,Y) = {hx + hy - hxy:.6f}')\n",
-    "check_close('symmetry', mi_xy, mi_yx)\n",
-    "check_close('entropy identity', mi_xy, hx + hy - hxy)\n",
-    "print('\n",
-    "Takeaway: mutual information can be computed exactly from a joint table and is symmetric.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 2 ★ -- Zero Correlation, Positive Mutual Information\n",
-    "\n",
-    "Let $X \\sim \\mathcal{N}(0,1)$ and $Y = X^2 + 0.1\u000b\n",
-    "arepsilon$ with independent Gaussian noise.\n",
-    "\n",
-    "**(a)** estimate the correlation between $X$ and $Y$.\n",
-    "\n",
-    "**(b)** estimate the mutual information using a simple histogram estimator.\n",
-    "\n",
-    "**(c)** explain why the two quantities tell different stories."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 2: Your Solution\n",
-    "np.random.seed(42)\n",
-    "N = 5000\n",
-    "X = np.random.randn(N)\n",
-    "Y = X**2 + 0.1 * np.random.randn(N)\n",
-    "\n",
-    "corr = None  # YOUR CODE HERE\n",
-    "mi_est = None  # YOUR CODE HERE\n",
-    "\n",
-    "print('corr =', corr)\n",
-    "print('mi_est =', mi_est)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 2: Solution\n",
-    "np.random.seed(42)\n",
-    "N = 5000\n",
-    "X = np.random.randn(N)\n",
-    "Y = X**2 + 0.1 * np.random.randn(N)\n",
-    "\n",
-    "corr = np.corrcoef(X, Y)[0, 1]\n",
-    "mi_est = histogram_mi(X, Y, bins=30)\n",
-    "\n",
-    "header('Exercise 2: Zero Correlation, Positive MI')\n",
-    "print(f'Correlation estimate: {corr:.6f}')\n",
-    "print(f'Histogram MI estimate: {mi_est:.6f}')\n",
-    "check_true('correlation is small in magnitude', abs(corr) < 0.1)\n",
-    "check_true('mutual information is positive', mi_est > 0.2)\n",
-    "print('\n",
-    "Takeaway: correlation can miss nonlinear dependence, but mutual information still detects it.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 3 ★ -- Mutual Information as KL Divergence\n",
-    "\n",
-    "For the same table as Exercise 1, compute\n",
-    "\n",
-    "$$D_{\\mathrm{KL}}(P_{XY} \\| P_X P_Y)$$\n",
-    "\n",
-    "and verify that it equals mutual information.\n",
-    "\n",
-    "Also check that if the joint table factorizes exactly, the mutual information is zero."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 3: Your Solution\n",
-    "P = np.array([[0.40, 0.10],\n",
-    "              [0.10, 0.40]])\n",
-    "\n",
-    "product = None  # YOUR CODE HERE\n",
-    "kl_val = None   # YOUR CODE HERE\n",
-    "mi_val = None   # YOUR CODE HERE\n",
-    "\n",
-    "P_ind = np.outer(np.array([0.5, 0.5]), np.array([0.6, 0.4]))\n",
-    "mi_ind = None   # YOUR CODE HERE\n",
-    "\n",
-    "print('kl_val =', kl_val)\n",
-    "print('mi_val =', mi_val)\n",
-    "print('mi_ind =', mi_ind)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 3: Solution\n",
-    "P = np.array([[0.40, 0.10],\n",
-    "              [0.10, 0.40]])\n",
-    "product = np.outer(P.sum(axis=1), P.sum(axis=0))\n",
-    "kl_val = np.sum(np.where(P > 0, P * np.log(P / product), 0.0))\n",
-    "mi_val = mutual_info_from_joint(P)\n",
-    "\n",
-    "P_ind = np.outer(np.array([0.5, 0.5]), np.array([0.6, 0.4]))\n",
-    "mi_ind = mutual_info_from_joint(P_ind)\n",
-    "\n",
-    "header('Exercise 3: MI as KL Divergence')\n",
-    "print(f'KL(P_xy || P_x P_y) = {kl_val:.6f}')\n",
-    "print(f'I(X;Y)              = {mi_val:.6f}')\n",
-    "print(f'I(X;Y) for independent table = {mi_ind:.6f}')\n",
-    "check_close('MI equals KL to independence', mi_val, kl_val)\n",
-    "check_close('independent table has zero MI', mi_ind, 0.0)\n",
-    "print('\n",
-    "Takeaway: mutual information is exactly the KL divergence from the true joint law to the independence model.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 4 ★★ -- Chain Rule and Conditional Mutual Information\n",
-    "\n",
-    "Construct a three-variable discrete system and verify\n",
-    "\n",
-    "$$I(X,Z;Y) = I(X;Y) + I(Z;Y \\mid X).$$\n",
-    "\n",
-    "Use the synthetic model from the theory notebook:\n",
-    "$X, Z \\sim \\operatorname{Bern}(1/2)$ independently and\n",
-    "$Y = (X + Z + N) \bmod 2$ with $N \\sim \\operatorname{Bern}(0.2)$."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 4: Your Solution\n",
-    "np.random.seed(11)\n",
-    "N = 200000\n",
-    "X = np.random.binomial(1, 0.5, size=N)\n",
-    "Z = np.random.binomial(1, 0.5, size=N)\n",
-    "Y = (X + Z + np.random.binomial(1, 0.2, size=N)) % 2\n",
-    "\n",
-    "# Build joint table and compute both sides of the identity.\n",
-    "lhs = None  # YOUR CODE HERE\n",
-    "rhs = None  # YOUR CODE HERE\n",
-    "\n",
-    "print('lhs =', lhs)\n",
-    "print('rhs =', rhs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 4: Solution\n",
-    "np.random.seed(11)\n",
-    "N = 200000\n",
-    "X = np.random.binomial(1, 0.5, size=N)\n",
-    "Z = np.random.binomial(1, 0.5, size=N)\n",
-    "Y = (X + Z + np.random.binomial(1, 0.2, size=N)) % 2\n",
-    "\n",
-    "Pxyz = np.zeros((2, 2, 2), dtype=float)\n",
-    "for x, z, y in zip(X, Z, Y):\n",
-    "    Pxyz[x, z, y] += 1\n",
-    "Pxyz /= N\n",
-    "\n",
-    "lhs = mutual_info_from_joint(Pxyz.reshape(4, 2))\n",
-    "rhs = mutual_info_from_joint(Pxyz.sum(axis=1)) + conditional_mi_from_joint_xyz(np.transpose(Pxyz, (1, 2, 0)))\n",
-    "\n",
-    "header('Exercise 4: Chain Rule')\n",
-    "print(f'I((X,Z);Y)      = {lhs:.6f}')\n",
-    "print(f'I(X;Y)+I(Z;Y|X) = {rhs:.6f}')\n",
-    "check_close('chain rule', lhs, rhs, tol=2e-3)\n",
-    "print('\n",
-    "Takeaway: chain rules decompose information into what is already explained and what is added conditionally.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 5 ★★ -- Binary Symmetric Channel and Capacity\n",
-    "\n",
-    "For a binary symmetric channel with flip probability $\\epsilon$ and a uniform input,\n",
-    "\n",
-    "$$I(X;Y) = \\log 2 - h_2(\\epsilon)$$\n",
-    "\n",
-    "in nats.\n",
-    "\n",
-    "**(a)** compute the mutual information at $\\epsilon = 0.1, 0.25, 0.49$.\n",
-    "\n",
-    "**(b)** verify that the mutual information decreases as noise increases."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 5: Your Solution\n",
-    "epsilons = np.array([0.10, 0.25, 0.49])\n",
-    "mi_vals = None  # YOUR CODE HERE\n",
-    "\n",
-    "print('mi_vals =', mi_vals)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 5: Solution\n",
-    "epsilons = np.array([0.10, 0.25, 0.49])\n",
-    "mi_vals = np.log(2) - binary_entropy(epsilons)\n",
-    "\n",
-    "header('Exercise 5: Binary Symmetric Channel')\n",
-    "for e, m in zip(epsilons, mi_vals):\n",
-    "    print(f'epsilon={e:.2f} -> I(X;Y)={m:.6f} nats')\n",
-    "check_true('mutual information decreases with noise', np.all(np.diff(mi_vals) < 0))\n",
-    "print('\n",
-    "Takeaway: channel noise destroys information, and capacity falls accordingly.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 6 ★★ -- Estimator Bias in Practice\n",
-    "\n",
-    "Estimate mutual information for a correlated Gaussian pair with a simple histogram estimator.\n",
-    "Use $\n",
-    "ho = 0.6$ and compare the estimate with the exact Gaussian formula\n",
-    "\n",
-    "$$I(X;Y) = -\tfrac12 \\log(1-\n",
-    "ho^2).$$\n",
-    "\n",
-    "Repeat for two different bin counts and interpret the difference."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 6: Your Solution\n",
-    "np.random.seed(5)\n",
-    "rho = 0.6\n",
-    "cov = np.array([[1.0, rho], [rho, 1.0]])\n",
-    "XY = np.random.multivariate_normal([0.0, 0.0], cov, size=4000)\n",
-    "true_mi = None  # YOUR CODE HERE\n",
-    "est_12 = None   # YOUR CODE HERE\n",
-    "est_30 = None   # YOUR CODE HERE\n",
-    "\n",
-    "print(true_mi, est_12, est_30)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 6: Solution\n",
-    "np.random.seed(5)\n",
-    "rho = 0.6\n",
-    "cov = np.array([[1.0, rho], [rho, 1.0]])\n",
-    "XY = np.random.multivariate_normal([0.0, 0.0], cov, size=4000)\n",
-    "true_mi = -0.5 * np.log(1 - rho**2)\n",
-    "est_12 = histogram_mi(XY[:, 0], XY[:, 1], bins=12)\n",
-    "est_30 = histogram_mi(XY[:, 0], XY[:, 1], bins=30)\n",
-    "\n",
-    "header('Exercise 6: Estimator Bias')\n",
-    "print(f'True Gaussian MI   = {true_mi:.6f}')\n",
-    "print(f'Histogram estimate (12 bins) = {est_12:.6f}')\n",
-    "print(f'Histogram estimate (30 bins) = {est_30:.6f}')\n",
-    "check_true('estimates are positive', est_12 > 0 and est_30 > 0)\n",
-    "check_true('different bin counts give different estimates', abs(est_12 - est_30) > 1e-3)\n",
-    "print('\n",
-    "Takeaway: mutual-information estimation is sensitive to estimator design even on simple continuous problems.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 7 ★★★ -- InfoNCE as a Lower-Bound-Style Objective\n",
-    "\n",
-    "Use correlated Gaussian views $Z_1, Z_2$ with correlation $\n",
-    "ho = 0.8$.\n",
-    "Compute an InfoNCE-style lower bound with $K=8$ and $K=64$ negatives and compare with the exact Gaussian MI.\n",
-    "\n",
-    "You do not need to prove the bound here; focus on the computation and interpretation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 7: Your Solution\n",
-    "np.random.seed(123)\n",
-    "N = 3000\n",
-    "rho = 0.8\n",
-    "z1 = np.random.randn(N, 1)\n",
-    "z2 = rho * z1 + np.sqrt(1 - rho**2) * np.random.randn(N, 1)\n",
-    "\n",
-    "# Define a helper and compare K=8 vs K=64.\n",
-    "def infonce_bound(K, temperature=0.2):\n",
-    "    return None  # YOUR CODE HERE\n",
-    "\n",
-    "bound_8 = infonce_bound(8)\n",
-    "bound_64 = infonce_bound(64)\n",
-    "true_mi = None  # YOUR CODE HERE\n",
-    "\n",
-    "print(bound_8, bound_64, true_mi)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 7: Solution\n",
-    "np.random.seed(123)\n",
-    "N = 3000\n",
-    "rho = 0.8\n",
-    "z1 = np.random.randn(N, 1)\n",
-    "z2 = rho * z1 + np.sqrt(1 - rho**2) * np.random.randn(N, 1)\n",
-    "\n",
-    "def infonce_bound(K, temperature=0.2):\n",
-    "    idx = np.random.choice(N, size=400, replace=False)\n",
-    "    x = z1[idx]\n",
-    "    y_pos = z2[idx]\n",
-    "    pos = (x * y_pos)[:, 0] / temperature\n",
-    "    losses = []\n",
-    "    for i, score in enumerate(pos):\n",
-    "        neg_idx = np.random.choice(N, size=K - 1, replace=False)\n",
-    "        neg = (x[i] * z2[neg_idx]).reshape(-1) / temperature\n",
-    "        all_scores = np.concatenate([[score], neg])\n",
-    "        losses.append(-score + np.log(np.sum(np.exp(all_scores))))\n",
-    "    return np.log(K) - np.mean(losses)\n",
-    "\n",
-    "bound_8 = infonce_bound(8)\n",
-    "bound_64 = infonce_bound(64)\n",
-    "true_mi = -0.5 * np.log(1 - rho**2)\n",
-    "\n",
-    "header('Exercise 7: InfoNCE Lower Bound')\n",
-    "print(f'Bound with K=8:   {bound_8:.6f}')\n",
-    "print(f'Bound with K=64:  {bound_64:.6f}')\n",
-    "print(f'True Gaussian MI: {true_mi:.6f}')\n",
-    "check_true('bounds are below the true MI up to small estimator noise', bound_8 <= true_mi + 0.5 and bound_64 <= true_mi + 0.5)\n",
-    "check_true('more negatives usually tighten the bound', bound_64 >= bound_8 - 1e-6)\n",
-    "print('\n",
-    "Takeaway: InfoNCE behaves like a practical lower-bound objective, not the mutual information itself.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Exercise 8 ★★★ -- Active Learning via Mutual Information\n",
-    "\n",
-    "Suppose the model state $\\Theta \\in \\{0,1\\}$ is equally likely a priori. For a candidate input $x$, the unknown label $Y$ is Bernoulli with parameter:\n",
-    "\n",
-    "- $P(Y=1 \\mid \\Theta=0, x)$\n",
-    "- $P(Y=1 \\mid \\Theta=1, x)$\n",
-    "\n",
-    "Compute the BALD-style score $I(Y;\\Theta \\mid x)$ for three candidates and choose the best one.\n",
-    "\n",
-    "Candidates:\n",
-    "\n",
-    "- uninformative: $(0.50, 0.50)$\n",
-    "- moderate: $(0.75, 0.25)$\n",
-    "- very informative: $(0.95, 0.05)$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 8: Your Solution\n",
-    "candidates = {\n",
-    "    'uninformative': (0.50, 0.50),\n",
-    "    'moderate': (0.75, 0.25),\n",
-    "    'very informative': (0.95, 0.05),\n",
-    "}\n",
-    "\n",
-    "def bald_score(p0, p1):\n",
-    "    return None  # YOUR CODE HERE\n",
-    "\n",
-    "scores = {name: bald_score(*vals) for name, vals in candidates.items()}\n",
-    "print(scores)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Exercise 8: Solution\n",
-    "candidates = {\n",
-    "    'uninformative': (0.50, 0.50),\n",
-    "    'moderate': (0.75, 0.25),\n",
-    "    'very informative': (0.95, 0.05),\n",
-    "}\n",
-    "\n",
-    "def bald_score(p0, p1):\n",
-    "    p_theta = np.array([0.5, 0.5])\n",
-    "    p_y1 = np.dot(p_theta, [p0, p1])\n",
-    "    H_y = binary_entropy(p_y1)\n",
-    "    H_y_given_theta = 0.5 * binary_entropy(p0) + 0.5 * binary_entropy(p1)\n",
-    "    return H_y - H_y_given_theta\n",
-    "\n",
-    "scores = {name: bald_score(*vals) for name, vals in candidates.items()}\n",
-    "best = max(scores, key=scores.get)\n",
-    "\n",
-    "header('Exercise 8: Active Learning via Mutual Information')\n",
-    "for name, score in scores.items():\n",
-    "    print(f'{name:>16}: {score:.6f} nats')\n",
-    "print(f'Best query: {best}')\n",
-    "check_true('the most separated candidate is most informative', best == 'very informative')\n",
-    "check_true('uninformative query has zero information gain', abs(scores['uninformative']) < 1e-10)\n",
-    "print('\n",
-    "Takeaway: active learning prefers queries whose labels would most reduce uncertainty about the model state.')"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/09-Information-Theory/03-Mutual-Information/notes.md
+++ b/09-Information-Theory/03-Mutual-Information/notes.md
@@ -36,7 +36,7 @@ After completing this section, you will:
 
 1. Define mutual information in discrete and continuous settings and explain why it measures dependence rather than mere correlation
 2. Derive the equivalent forms
-   \(I(X;Y) = H(X) - H(X \mid Y) = H(Y) - H(Y \mid X) = D_{\mathrm{KL}}(p_{XY}\|p_X p_Y)\)
+   $I(X;Y) = H(X) - H(X \mid Y) = H(Y) - H(Y \mid X) = D_{\mathrm{KL}}(p_{XY} \Vert p_X p_Y)$
 3. Interpret pointwise mutual information and explain why PMI is central in co-occurrence models and embedding methods
 4. State and prove the most important properties of mutual information: symmetry, non-negativity, upper bounds, and the independence criterion
 5. Use chain rules for mutual information and conditional mutual information to reason about information flow in multi-variable systems
@@ -114,11 +114,11 @@ The easiest way to misunderstand mutual information is to think of it as "just a
 
 Consider three examples:
 
-1. If \(Y = 2X + 1\) with no noise, then \(X\) and \(Y\) are perfectly dependent and both correlation and mutual information are large.
-2. If \(X \in \{-1,+1\}\) uniformly and \(Y = X^2\), then \(Y\) is constant. Correlation is zero and mutual information is also zero because observing \(Y\) teaches us nothing.
-3. If \(X \sim \mathcal{N}(0,1)\) and \(Y = X^2\), then correlation can be zero because the relationship is symmetric around zero, yet mutual information is positive because knowing \(Y\) narrows down what values of \(X\) are plausible.
+1. If $Y = 2X + 1$ with no noise, then $X$ and $Y$ are perfectly dependent and both correlation and mutual information are large.
+2. If $X \in \{-1,+1\}$ uniformly and $Y = X^2$, then $Y$ is constant. Correlation is zero and mutual information is also zero because observing $Y$ teaches us nothing.
+3. If $X \sim \mathcal{N}(0,1)$ and $Y = X^2$, then correlation can be zero because the relationship is symmetric around zero, yet mutual information is positive because knowing $Y$ narrows down what values of $X$ are plausible.
 
-This third example is the important one. Zero covariance does **not** imply independence except in special families such as jointly Gaussian distributions. Mutual information detects dependence whenever the joint distribution \(p_{XY}\) fails to factorize as \(p_X p_Y\), regardless of whether the dependence is linear, nonlinear, monotone, multimodal, or structurally conditional.
+This third example is the important one. Zero covariance does **not** imply independence except in special families such as jointly Gaussian distributions. Mutual information detects dependence whenever the joint distribution $p_{XY}$ fails to factorize as $p_X p_Y$, regardless of whether the dependence is linear, nonlinear, monotone, multimodal, or structurally conditional.
 
 ```text
 DEPENDENCE VS CORRELATION
@@ -154,26 +154,26 @@ This is why mutual information matters so much in representation learning. Usefu
 
 Entropy gives a baseline uncertainty. Conditional entropy gives the uncertainty that remains after an observation. Mutual information is the gap:
 
-\[
+$$
 I(X;Y) = H(X) - H(X \mid Y).
-\]
+$$
 
-That formula is worth reading slowly. Before observing \(Y\), uncertainty about \(X\) is \(H(X)\). After observing \(Y\), the average remaining uncertainty is \(H(X \mid Y)\). Their difference is the *average reduction in uncertainty* due to the observation of \(Y\).
+That formula is worth reading slowly. Before observing $Y$, uncertainty about $X$ is $H(X)$. After observing $Y$, the average remaining uncertainty is $H(X \mid Y)$. Their difference is the *average reduction in uncertainty* due to the observation of $Y$.
 
 Because the same reasoning works in the other direction,
 
-\[
+$$
 I(X;Y) = H(Y) - H(Y \mid X),
-\]
+$$
 
 mutual information is symmetric. The quantity measures *shared* uncertainty reduction.
 
-For a concrete discrete example, imagine a noisy binary label \(Y\) generated from a feature \(X\):
+For a concrete discrete example, imagine a noisy binary label $Y$ generated from a feature $X$:
 
-- if \(X\) is uninformative, then \(H(Y \mid X) \approx H(Y)\), so \(I(X;Y) \approx 0\)
-- if \(X\) almost determines \(Y\), then \(H(Y \mid X)\) is small, so \(I(X;Y)\) is close to \(H(Y)\)
+- if $X$ is uninformative, then $H(Y \mid X) \approx H(Y)$, so $I(X;Y) \approx 0$
+- if $X$ almost determines $Y$, then $H(Y \mid X)$ is small, so $I(X;Y)$ is close to $H(Y)$
 
-This is the logic behind information gain520472
+This is the logic behind information gain in decision trees and many feature-selection criteria.
 
 ```text
 UNCERTAINTY REDUCTION VIEW
@@ -204,11 +204,11 @@ Mutual information appears whenever a learning system must preserve some aspects
 
 | AI setting | Variables | MI question |
 | --- | --- | --- |
-| Decision trees | feature \(X_j\), class \(Y\) | how much does the feature reduce label uncertainty? |
-| Contrastive learning | view \(X\), view \(Y\) of same sample | how much shared content can the representation preserve across views? |
-| Multimodal learning | image \(X\), caption \(Y\) | how much common semantic content is aligned between modalities? |
-| Active learning | query \(X\), unknown label \(Y\) or parameter \(\Theta\) | which observation will be maximally informative? |
-| Representation learning | raw input \(X\), latent code \(T\), target \(Y\) | how much of \(X\) should \(T\) keep, and how much task-relevant info should remain? |
+| Decision trees | feature $X_j$, class $Y$ | how much does the feature reduce label uncertainty? |
+| Contrastive learning | view $X$, view $Y$ of same sample | how much shared content can the representation preserve across views? |
+| Multimodal learning | image $X$, caption $Y$ | how much common semantic content is aligned between modalities? |
+| Active learning | query $X$, unknown label $Y$ or parameter $\Theta$ | which observation will be maximally informative? |
+| Representation learning | raw input $X$, latent code $T$, target $Y$ | how much of $X$ should $T$ keep, and how much task-relevant info should remain? |
 
 The core pattern is always the same:
 
@@ -284,42 +284,42 @@ Mutual information began life in communication theory, but today it is equally a
 
 ### 2.1 Discrete Mutual Information
 
-Let \(X\) and \(Y\) be discrete random variables with joint PMF \(p_{XY}(x,y)\) and marginals \(p_X(x)\), \(p_Y(y)\). The discrete mutual information is
+Let $X$ and $Y$ be discrete random variables with joint PMF $p_{XY}(x,y)$ and marginals $p_X(x)$, $p_Y(y)$. The discrete mutual information is
 
-\[
+$$
 I(X;Y) = \sum_{x,y} p_{XY}(x,y)\log\frac{p_{XY}(x,y)}{p_X(x)p_Y(y)}.
-\]
+$$
 
 Equivalent entropy forms are
 
-\[
+$$
 I(X;Y) = H(X) + H(Y) - H(X,Y)
-\]
+$$
 
 and
 
-\[
+$$
 I(X;Y) = H(X) - H(X\mid Y) = H(Y) - H(Y\mid X).
-\]
+$$
 
 These formulas are equivalent whenever the entropies are finite.
 
-**Worked example.** Suppose \(X,Y \in \{0,1\}\) with
+**Worked example.** Suppose $X,Y \in \{0,1\}$ with
 
-\[
+$$
 \begin{array}{c|cc}
  & Y=0 & Y=1 \\ \hline
 X=0 & 0.4 & 0.1 \\
 X=1 & 0.1 & 0.4
 \end{array}
-\]
+$$
 
-Then \(p_X(0)=p_X(1)=0.5\) and \(p_Y(0)=p_Y(1)=0.5\). So
+Then $p_X(0)=p_X(1)=0.5$ and $p_Y(0)=p_Y(1)=0.5$. So
 
-\[
+$$
 I(X;Y) = 0.4\log\frac{0.4}{0.25} + 0.1\log\frac{0.1}{0.25}
 + 0.1\log\frac{0.1}{0.25} + 0.4\log\frac{0.4}{0.25}.
-\]
+$$
 
 The positive contributions come from outcomes that occur more often jointly than independence would predict. Negative pointwise contributions can also occur for individually "anti-associated" outcomes, but the overall sum is always nonnegative.
 
@@ -327,45 +327,45 @@ The positive contributions come from outcomes that occur more often jointly than
 
 The identity
 
-\[
-I(X;Y) = D_{\mathrm{KL}}(p_{XY}\|p_X p_Y)
-\]
+$$
+I(X;Y) = D_{\mathrm{KL}}(p_{XY} \Vert p_X p_Y)
+$$
 
 is one of the most important equations in the chapter.
 
 It says mutual information is the KL divergence between:
 
-- the **actual joint distribution** \(p_{XY}\), and
-- the **independence model** \(p_X p_Y\) built from the marginals.
+- the **actual joint distribution** $p_{XY}$, and
+- the **independence model** $p_X p_Y$ built from the marginals.
 
 This is conceptually powerful because it turns a dependence question into a distribution-comparison question:
 
-- if \(X\) and \(Y\) are independent, then \(p_{XY}=p_X p_Y\), so the divergence is zero
+- if $X$ and $Y$ are independent, then $p_{XY}=p_X p_Y$, so the divergence is zero
 - if they are dependent, the joint law differs from the product law, and the divergence is positive
 
-> **Backward link:** the general properties of \(D_{\mathrm{KL}}\) belong to [02-KL-Divergence](../02-KL-Divergence/notes.md). In this section we use that theory to inherit non-negativity, but the object of interest is specifically the divergence to the product-of-marginals baseline.
+> **Backward link:** the general properties of $D_{\mathrm{KL}}$ belong to [02-KL-Divergence](../02-KL-Divergence/notes.md). In this section we use that theory to inherit non-negativity, but the object of interest is specifically the divergence to the product-of-marginals baseline.
 
 This perspective also clarifies why mutual information is invariant under invertible reparameterizations in both arguments: KL divergence between corresponding transformed measures is unchanged.
 
 ### 2.3 Pointwise Mutual Information (PMI)
 
-The **pointwise mutual information** between a specific pair \((x,y)\) is
+The **pointwise mutual information** between a specific pair $(x,y)$ is
 
-\[
+$$
 \operatorname{pmi}(x,y) = \log\frac{p_{XY}(x,y)}{p_X(x)p_Y(y)}.
-\]
+$$
 
 Mutual information is the expectation of PMI:
 
-\[
+$$
 I(X;Y) = \mathbb{E}_{(X,Y)\sim p_{XY}}[\operatorname{pmi}(X,Y)].
-\]
+$$
 
 PMI is more local than MI:
 
-- \(\operatorname{pmi}(x,y) > 0\) means the pair co-occurs more often than independence predicts
-- \(\operatorname{pmi}(x,y) = 0\) means the pair occurs exactly as often as independence predicts
-- \(\operatorname{pmi}(x,y) < 0\) means the pair co-occurs less often than independence predicts
+- $\operatorname{pmi}(x,y) > 0$ means the pair co-occurs more often than independence predicts
+- $\operatorname{pmi}(x,y) = 0$ means the pair occurs exactly as often as independence predicts
+- $\operatorname{pmi}(x,y) < 0$ means the pair co-occurs less often than independence predicts
 
 In NLP, PMI has historically been used to score word associations:
 
@@ -378,21 +378,21 @@ This matters because co-occurrence counts alone are dominated by frequent tokens
 
 ### 2.4 Continuous Mutual Information
 
-For continuous random variables with joint density \(p_{XY}(x,y)\) and marginal densities \(p_X(x)\), \(p_Y(y)\), the mutual information is
+For continuous random variables with joint density $p_{XY}(x,y)$ and marginal densities $p_X(x)$, $p_Y(y)$, the mutual information is
 
-\[
+$$
 I(X;Y) = \int \int p_{XY}(x,y)\log\frac{p_{XY}(x,y)}{p_X(x)p_Y(y)}\,dx\,dy,
-\]
+$$
 
 provided the integral is well defined.
 
 This is **not** simply a difference of differential entropies in the naive sense unless the needed quantities exist. But when they do,
 
-\[
+$$
 I(X;Y) = h(X) - h(X\mid Y) = h(Y) - h(Y\mid X),
-\]
+$$
 
-where \(h\) denotes differential entropy.
+where $h$ denotes differential entropy.
 
 The subtle but crucial fact is:
 
@@ -405,30 +405,30 @@ That is one reason mutual information is often a safer continuous information me
 
 The **conditional mutual information** is
 
-\[
+$$
 I(X;Y\mid Z) = H(X\mid Z) - H(X\mid Y,Z).
-\]
+$$
 
 It can also be written as
 
-\[
+$$
 I(X;Y\mid Z)
-= \sum_z p_Z(z)\, D_{\mathrm{KL}}(p_{XY\mid Z=z}\|p_{X\mid Z=z}p_{Y\mid Z=z}),
-\]
+= \sum_z p_Z(z)\, D_{\mathrm{KL}}(p_{XY\mid Z=z} \Vert p_{X\mid Z=z} p_{Y\mid Z=z}),
+$$
 
 or, in expectation form,
 
-\[
+$$
 I(X;Y\mid Z)
 = \mathbb{E}\left[\log\frac{p_{XY\mid Z}(X,Y\mid Z)}{p_{X\mid Z}(X\mid Z)p_{Y\mid Z}(Y\mid Z)}\right].
-\]
+$$
 
 The interpretation is straightforward:
 
-- first condition on \(Z\)
-- then ask how much extra uncertainty about \(X\) is reduced by seeing \(Y\)
+- first condition on $Z$
+- then ask how much extra uncertainty about $X$ is reduced by seeing $Y$
 
-So \(I(X;Y\mid Z)\) measures information shared by \(X\) and \(Y\) *beyond what \(Z\) already explains*.
+So $I(X;Y\mid Z)$ measures information shared by $X$ and $Y$ *beyond what $Z$ already explains*.
 
 This quantity becomes central in graphical models, causal reasoning, and active-learning design because it separates direct information from information already mediated by other variables.
 
@@ -440,25 +440,25 @@ This quantity becomes central in graphical models, causal reasoning, and active-
 
 Mutual information is symmetric:
 
-\[
+$$
 I(X;Y)=I(Y;X).
-\]
+$$
 
-This is immediate from the entropy formula \(H(X)+H(Y)-H(X,Y)\), which is symmetric in \(X\) and \(Y\).
+This is immediate from the entropy formula $H(X)+H(Y)-H(X,Y)$, which is symmetric in $X$ and $Y$.
 
 It is also nonnegative:
 
-\[
+$$
 I(X;Y)\ge 0.
-\]
+$$
 
 The cleanest proof uses the KL representation:
 
-\[
-I(X;Y)=D_{\mathrm{KL}}(p_{XY}\|p_X p_Y)\ge 0.
-\]
+$$
+I(X;Y)=D_{\mathrm{KL}}(p_{XY} \Vert p_X p_Y)\ge 0.
+$$
 
-Equality holds if and only if \(p_{XY}=p_X p_Y\) almost everywhere, i.e. \(X\) and \(Y\) are independent.
+Equality holds if and only if $p_{XY}=p_X p_Y$ almost everywhere, i.e. $X$ and $Y$ are independent.
 
 This already tells us something profound: mutual information is a dependence measure with a mathematically exact zero point. Many statistics do not enjoy that property.
 
@@ -466,34 +466,34 @@ This already tells us something profound: mutual information is a dependence mea
 
 Because conditioning cannot increase entropy,
 
-\[
+$$
 H(X\mid Y)\le H(X).
-\]
+$$
 
 Therefore
 
-\[
+$$
 I(X;Y)=H(X)-H(X\mid Y)\le H(X).
-\]
+$$
 
 By symmetry,
 
-\[
+$$
 I(X;Y)\le H(Y),
-\]
+$$
 
 so overall
 
-\[
+$$
 0 \le I(X;Y) \le \min\{H(X),H(Y)\}.
-\]
+$$
 
 When do we attain the upper bound?
 
-- \(I(X;Y)=H(X)\) if and only if \(H(X\mid Y)=0\), meaning \(X\) is a deterministic function of \(Y\)
-- \(I(X;Y)=H(Y)\) if and only if \(H(Y\mid X)=0\), meaning \(Y\) is a deterministic function of \(X\)
+- $I(X;Y)=H(X)$ if and only if $H(X\mid Y)=0$, meaning $X$ is a deterministic function of $Y$
+- $I(X;Y)=H(Y)$ if and only if $H(Y\mid X)=0$, meaning $Y$ is a deterministic function of $X$
 
-If both hold, then \(X\) and \(Y\) determine one another almost surely: they are invertibly linked up to null sets.
+If both hold, then $X$ and $Y$ determine one another almost surely: they are invertibly linked up to null sets.
 
 ```text
 BOUNDS ON MUTUAL INFORMATION
@@ -523,11 +523,11 @@ Extreme cases:
 
 This property is so important that it deserves its own subsection:
 
-\[
+$$
 I(X;Y)=0 \quad \Longleftrightarrow \quad X \perp\!\!\!\perp Y.
-\]
+$$
 
-The forward implication follows from KL non-negativity and equality conditions. The reverse implication follows by direct substitution: if \(p_{XY}=p_Xp_Y\), every log-ratio term becomes zero.
+The forward implication follows from KL non-negativity and equality conditions. The reverse implication follows by direct substitution: if $p_{XY}=p_X p_Y$, every log-ratio term becomes zero.
 
 This criterion is much stronger than:
 
@@ -537,37 +537,37 @@ This criterion is much stronger than:
 
 Those can all vanish in the presence of nonlinear dependence. Mutual information vanishes only when there is no statistical dependence at all.
 
-**Gaussian exception.** If \((X,Y)\) are jointly Gaussian, then zero covariance does imply independence. That is why, in Gaussian settings, MI can be expressed entirely through covariance structure. Outside that setting, covariance is only a partial picture.
+**Gaussian exception.** If $(X,Y)$ are jointly Gaussian, then zero covariance does imply independence. That is why, in Gaussian settings, MI can be expressed entirely through covariance structure. Outside that setting, covariance is only a partial picture.
 
 ### 3.4 Chain Rules for Mutual Information
 
 The mutual-information chain rule states
 
-\[
+$$
 I(X_1,\dots,X_n;Y)
 = \sum_{i=1}^n I(X_i;Y\mid X_1,\dots,X_{i-1}).
-\]
+$$
 
 For two variables this is
 
-\[
+$$
 I(X,Z;Y)=I(X;Y)+I(Z;Y\mid X).
-\]
+$$
 
 **Derivation.** Start from entropy:
 
-\[
+$$
 I(X,Z;Y)
 = H(Y)-H(Y\mid X,Z).
-\]
+$$
 
-Add and subtract \(H(Y\mid X)\):
+Add and subtract $H(Y\mid X)$:
 
-\[
+$$
 I(X,Z;Y)
 = \big(H(Y)-H(Y\mid X)\big) + \big(H(Y\mid X)-H(Y\mid X,Z)\big)
 = I(X;Y)+I(Z;Y\mid X).
-\]
+$$
 
 This is the information-theoretic analogue of decomposing predictive contribution into what is already explained and what is newly explained after conditioning.
 
@@ -580,22 +580,22 @@ In ML, chain rules appear whenever information is accumulated sequentially:
 
 ### 3.5 Deterministic Functions and Invariance Facts
 
-If \(T=f(X)\) is a deterministic function of \(X\), then
+If $T=f(X)$ is a deterministic function of $X$, then
 
-\[
+$$
 I(T;Y)\le I(X;Y).
-\]
+$$
 
 This is already a special case of the data processing inequality, but it is worth interpreting directly:
 
 - deterministic post-processing can discard information
-- it cannot create new information about \(Y\) that was not already present in \(X\)
+- it cannot create new information about $Y$ that was not already present in $X$
 
-If \(f\) is bijective, then no information is lost:
+If $f$ is bijective, then no information is lost:
 
-\[
+$$
 I(f(X);Y)=I(X;Y).
-\]
+$$
 
 This invariance under invertible reparameterization is one reason mutual information is conceptually robust. It depends on the dependence structure between variables, not the arbitrary coordinates in which the variables are represented.
 
@@ -611,8 +611,8 @@ Conditional mutual information is where dependence structure becomes interesting
 
 Two canonical patterns matter:
 
-1. **Common cause:** if \(Z\) influences both \(X\) and \(Y\), then \(X\) and \(Y\) may be dependent marginally, but conditioning on \(Z\) can remove the dependence.
-2. **Common effect (collider):** if \(X\) and \(Y\) both influence \(Z\), then \(X\) and \(Y\) may be marginally independent but become dependent after conditioning on \(Z\).
+1. **Common cause:** if $Z$ influences both $X$ and $Y$, then $X$ and $Y$ may be dependent marginally, but conditioning on $Z$ can remove the dependence.
+2. **Common effect (collider):** if $X$ and $Y$ both influence $Z$, then $X$ and $Y$ may be marginally independent but become dependent after conditioning on $Z$.
 
 This second phenomenon is often called **explaining away**. In diagnosis, two independent diseases can become negatively associated once a common symptom is observed: if one disease is present, it partly explains the symptom, reducing the need to attribute it to the other.
 
@@ -639,45 +639,45 @@ Reason:
 
 ### 4.2 Data Processing Inequality
 
-If \(X \to T \to Y\) forms a Markov chain, then
+If $X \to T \to Y$ forms a Markov chain, then
 
-\[
+$$
 I(X;Y)\le I(X;T).
-\]
+$$
 
-More commonly one writes, for \(X \to T \to Y\),
+More commonly one writes, for $X \to T \to Y$,
 
-\[
+$$
 I(X;Y)\le I(X;T)
 \quad\text{and}\quad
 I(T;Y)\le I(X;Y)
-\]
+$$
 only when the chain is ordered appropriately. The important statement is: **processing cannot increase information about the original source beyond what the intermediate representation already contains.**
 
 One proof uses the chain rule:
 
-\[
+$$
 I(X;T,Y)=I(X;T)+I(X;Y\mid T).
-\]
+$$
 
-Because \(X \to T \to Y\) means \(X\) and \(Y\) are conditionally independent given \(T\), we have \(I(X;Y\mid T)=0\). Hence
+Because $X \to T \to Y$ means $X$ and $Y$ are conditionally independent given $T$, we have $I(X;Y\mid T)=0$. Hence
 
-\[
+$$
 I(X;T,Y)=I(X;T).
-\]
+$$
 
 Also,
 
-\[
+$$
 I(X;T,Y)=I(X;Y)+I(X;T\mid Y)\ge I(X;Y),
-\]
+$$
 
-so \(I(X;Y)\le I(X;T)\).
+so $I(X;Y)\le I(X;T)$.
 
 This theorem is foundational for representation learning:
 
-- any learned representation \(T=f(X)\) is a processed form of the input
-- therefore \(T\) cannot contain more information about a downstream target than the input could possibly supply
+- any learned representation $T=f(X)$ is a processed form of the input
+- therefore $T$ cannot contain more information about a downstream target than the input could possibly supply
 - the design problem is not to create information, but to preserve the right information while discarding nuisance variation
 
 An equivalent way to say this is that representation learning is always
@@ -720,25 +720,25 @@ So the design goal is:
 
 ### 4.3 Markov Chains, Sufficiency, and Representation
 
-A statistic \(T(X)\) is sufficient for a parameter \(\Theta\) if conditioning on \(T\) renders \(X\) irrelevant to \(\Theta\). In information terms, sufficiency can be characterized as
+A statistic $T(X)$ is sufficient for a parameter $\Theta$ if conditioning on $T$ renders $X$ irrelevant to $\Theta$. In information terms, sufficiency can be characterized as
 
-\[
+$$
 I(\Theta;X\mid T)=0.
-\]
+$$
 
-That is a beautifully compact statement: once you know \(T\), the raw data \(X\) tells you nothing further about \(\Theta\).
+That is a beautifully compact statement: once you know $T$, the raw data $X$ tells you nothing further about $\Theta$.
 
 In representation learning, this suggests an ideal:
 
-- compress the raw input \(X\) into a representation \(T\)
-- but preserve the information in \(X\) that matters for the target \(Y\)
+- compress the raw input $X$ into a representation $T$
+- but preserve the information in $X$ that matters for the target $Y$
 
 The resulting design tension is the conceptual starting point for the information bottleneck:
 
-\[
+$$
 \text{small } I(X;T)
 \quad\text{but large } I(T;Y).
-\]
+$$
 
 This perspective is more general than any particular neural architecture. It is a way of asking what a representation should remember and what it should forget.
 
@@ -758,15 +758,15 @@ about *information about what?*
 
 ### 4.4 Interaction Information and Synergy
 
-Pairwise mutual information does not capture all multi-variable structure. Suppose two bits \(X_1\) and \(X_2\) are independent fair coins, and \(Y = X_1 \oplus X_2\) is their XOR.
+Pairwise mutual information does not capture all multi-variable structure. Suppose two bits $X_1$ and $X_2$ are independent fair coins, and $Y = X_1 \oplus X_2$ is their XOR.
 
 Then:
 
-- \(I(X_1;Y)=0\)
-- \(I(X_2;Y)=0\)
-- but \(I((X_1,X_2);Y)=1\) bit
+- $I(X_1;Y)=0$
+- $I(X_2;Y)=0$
+- but $I((X_1,X_2);Y)=1$ bit
 
-So neither variable individually tells us anything about \(Y\), but together they determine it completely. This is **synergy**.
+So neither variable individually tells us anything about $Y$, but together they determine it completely. This is **synergy**.
 
 Interaction information and related multivariate quantities attempt to formalize such effects. The sign conventions can be subtle, which is why many applied papers prefer partial-information decompositions or total correlation instead of relying on interaction information alone.
 
@@ -774,9 +774,9 @@ The key lesson is not the exact choice of multivariate information measure. It i
 
 One common definition of three-way interaction information is
 
-\[
+$$
 I(X;Y;Z) = I(X;Y) - I(X;Y\mid Z),
-\]
+$$
 
 with equivalent permutations obtained by symmetry. Under this sign convention,
 interaction information can be positive or negative:
@@ -800,19 +800,19 @@ therefore depends on the problem structure:
 
 ### 4.5 Total Correlation and Multi-Information
 
-For random variables \(X_1,\dots,X_n\), the **total correlation** (also called multi-information in one common convention) is
+For random variables $X_1,\dots,X_n$, the **total correlation** (also called multi-information in one common convention) is
 
-\[
+$$
 \operatorname{TC}(X_1,\dots,X_n)
-= D_{\mathrm{KL}}\!\left(p_{X_1,\dots,X_n}\,\middle\|\,\prod_{i=1}^n p_{X_i}\right).
-\]
+= D_{\mathrm{KL}}\!\left(p_{X_1,\dots,X_n}\,\middle\Vert \,\prod_{i=1}^n p_{X_i}\right).
+$$
 
 Equivalently,
 
-\[
+$$
 \operatorname{TC}(X_1,\dots,X_n)
 = \sum_{i=1}^n H(X_i) - H(X_1,\dots,X_n).
-\]
+$$
 
 This is the multivariate analogue of mutual information:
 
@@ -845,33 +845,33 @@ factorization.
 
 Mutual information can be written as
 
-\[
+$$
 I(X;Y)=\mathbb{E}\left[\log\frac{p_{Y\mid X}(Y\mid X)}{p_Y(Y)}\right].
-\]
+$$
 
 This form is especially intuitive:
 
-- \(p_Y(Y)\) is the baseline probability of the observation
-- \(p_{Y\mid X}(Y\mid X)\) is the probability after knowing \(X\)
-- the log-ratio is how much the observation becomes more or less likely once \(X\) is known
+- $p_Y(Y)$ is the baseline probability of the observation
+- $p_{Y\mid X}(Y\mid X)$ is the probability after knowing $X$
+- the log-ratio is how much the observation becomes more or less likely once $X$ is known
 
-Averaging gives the expected log-evidence gained from seeing \(X\).
+Averaging gives the expected log-evidence gained from seeing $X$.
 
 This is why MI naturally appears in communication, statistics, Bayesian experimental design, and likelihood-ratio thinking. It quantifies average evidence transfer.
 
 ### 5.2 Channel Mutual Information
 
-In a communication channel, \(X\) is the channel input and \(Y\) is the output after noise. The channel law is \(p(y\mid x)\). Once an input distribution \(p(x)\) is chosen, the joint law becomes
+In a communication channel, $X$ is the channel input and $Y$ is the output after noise. The channel law is $p(y\mid x)$. Once an input distribution $p(x)$ is chosen, the joint law becomes
 
-\[
+$$
 p(x,y)=p(x)p(y\mid x).
-\]
+$$
 
 The mutual information
 
-\[
+$$
 I(X;Y)
-\]
+$$
 
 measures how much information the output carries about the input under that chosen input distribution.
 
@@ -879,18 +879,18 @@ This is not yet channel capacity, because capacity optimizes over the input law.
 
 Another useful identity is
 
-\[
+$$
 I(X;Y)
-= \sum_x p(x)\,D_{\mathrm{KL}}\!\big(p_{Y\mid X=x}\,\|\,p_Y\big).
-\]
+= \sum_x p(x)\,D_{\mathrm{KL}}\!\big(p_{Y\mid X=x}\,\Vert\,p_Y\big).
+$$
 
 This says mutual information is the average KL divergence between:
 
-- the output distribution after a specific input symbol \(x\), and
+- the output distribution after a specific input symbol $x$, and
 - the unconditional output distribution before we know which symbol was sent
 
 So a channel has high MI when different inputs induce clearly distinguishable
-output distributions. If all the conditionals \(p(y\mid x)\) look nearly the
+output distributions. If all the conditionals $p(y\mid x)$ look nearly the
 same, then the output barely reveals which input was chosen and the channel
 carries little information.
 
@@ -903,9 +903,9 @@ class information the representation preserves.
 
 The **channel capacity** is
 
-\[
+$$
 C = \max_{p(x)} I(X;Y).
-\]
+$$
 
 Capacity is the largest rate at which information can be transmitted reliably through the channel in the limit of long block length. The theorem-level content belongs to full information-theory courses, but the conceptual meaning is essential:
 
@@ -933,24 +933,24 @@ that mechanism.
 
 ### 5.4 Binary Symmetric and Gaussian Channel Examples
 
-**Binary symmetric channel (BSC).** Let \(X \in \{0,1\}\) and suppose the channel flips the bit with probability \(\varepsilon\). If the input is Bernoulli-\(\tfrac12\), then
+**Binary symmetric channel (BSC).** Let $X \in \{0,1\}$ and suppose the channel flips the bit with probability $\varepsilon$. If the input is Bernoulli-$\tfrac12$, then
 
-\[
+$$
 I(X;Y)=1-h_2(\varepsilon),
-\]
+$$
 
-where \(h_2\) is the binary entropy function.
+where $h_2$ is the binary entropy function.
 
 This formula is perfect intuition:
 
-- if \(\varepsilon=0\), the channel is noiseless and MI is 1 bit
-- if \(\varepsilon=\tfrac12\), output is pure noise and MI is 0
+- if $\varepsilon=0$, the channel is noiseless and MI is 1 bit
+- if $\varepsilon=\tfrac12$, output is pure noise and MI is 0
 
-**Gaussian channel.** For \(Y=X+N\) with Gaussian noise \(N\sim \mathcal{N}(0,\sigma^2)\) and power constraint \(\mathbb{E}[X^2]\le P\), the capacity is
+**Gaussian channel.** For $Y=X+N$ with Gaussian noise $N\sim \mathcal{N}(0,\sigma^2)$ and power constraint $\mathbb{E}[X^2]\le P$, the capacity is
 
-\[
+$$
 C = \frac12 \log\left(1+\frac{P}{\sigma^2}\right)
-\]
+$$
 
 in nats per channel use.
 
@@ -975,15 +975,15 @@ the same: how distinguishable are the outputs induced by different inputs?
 
 ### 5.5 Fano's Inequality and Prediction Limits
 
-Fano's inequality connects mutual information to classification error. In one common form, if \(Y\) is a label drawn from \(M\) classes and \(\hat{Y}\) is an estimate based on observed data \(X\), then
+Fano's inequality connects mutual information to classification error. In one common form, if $Y$ is a label drawn from $M$ classes and $\hat{Y}$ is an estimate based on observed data $X$, then
 
-\[
+$$
 H(Y\mid X)\le h_2(P_e)+P_e\log(M-1),
-\]
+$$
 
-where \(P_e = \Pr[\hat{Y}\ne Y]\).
+where $P_e = \Pr[\hat{Y}\ne Y]$.
 
-Rearranging with \(I(X;Y)=H(Y)-H(Y\mid X)\) shows:
+Rearranging with $I(X;Y)=H(Y)-H(Y\mid X)$ shows:
 
 - small MI implies substantial irreducible prediction error
 - high prediction accuracy requires enough information about the label to flow through the observation
@@ -1054,37 +1054,37 @@ Because direct estimation is hard, many ML objectives optimize lower bounds on M
 
 **Donsker-Varadhan (DV) bound.** Since MI is a KL divergence,
 
-\[
-I(X;Y)=D_{\mathrm{KL}}(p_{XY}\|p_X p_Y),
-\]
+$$
+I(X;Y)=D_{\mathrm{KL}}(p_{XY} \Vert p_X p_Y),
+$$
 
 and KL admits variational representations. One such form is
 
-\[
-D_{\mathrm{KL}}(P\|Q)
+$$
+D_{\mathrm{KL}}(P \Vert Q)
 = \sup_T \left(\mathbb{E}_P[T]-\log \mathbb{E}_Q[e^T]\right).
-\]
+$$
 
-Applying this with \(P=p_{XY}\) and \(Q=p_X p_Y\) yields a lower-bound objective over critic functions \(T\).
+Applying this with $P=p_{XY}$ and $Q=p_X p_Y$ yields a lower-bound objective over critic functions $T$.
 
 **NWJ bound.** The Nguyen-Wainwright-Jordan family gives related lower bounds with different optimization behavior.
 
-**InfoNCE.** For a positive pair \((x,y)\) and negatives \(y_1^-,\dots,y_{K-1}^-\), the InfoNCE objective has the form
+**InfoNCE.** For a positive pair $(x,y)$ and negatives $y_1^-,\dots,y_{K-1}^-$, the InfoNCE objective has the form
 
-\[
+$$
 \mathcal{L}_{\mathrm{InfoNCE}}
 = -\mathbb{E}\left[
 \log
 \frac{\exp s(x,y)}
 {\exp s(x,y)+\sum_{j=1}^{K-1}\exp s(x,y_j^-)}
 \right],
-\]
+$$
 
 and implies the lower bound
 
-\[
+$$
 I(X;Y)\ge \log K - \mathcal{L}_{\mathrm{InfoNCE}}
-\]
+$$
 
 under the relevant sampling assumptions.
 
@@ -1115,7 +1115,7 @@ bound itself.
 
 ### 6.4 MINE and Neural Estimators
 
-Belghazi et al. (2018) introduced **MINE**: Mutual Information Neural Estimation. The core idea is to parameterize the critic \(T_\phi(x,y)\) with a neural network and optimize the DV lower bound by gradient descent.
+Belghazi et al. (2018) introduced **MINE**: Mutual Information Neural Estimation. The core idea is to parameterize the critic $T_\phi(x,y)$ with a neural network and optimize the DV lower bound by gradient descent.
 
 This made MI estimation compatible with deep learning pipelines, but brought new complications:
 
@@ -1133,16 +1133,16 @@ the axis itself is not an oracle.
 
 ### 6.5 Information Bottleneck
 
-The **information bottleneck** objective introduces a representation \(T\) of input \(X\) and target \(Y\), then optimizes
+The **information bottleneck** objective introduces a representation $T$ of input $X$ and target $Y$, then optimizes
 
-\[
+$$
 \min_{p(t\mid x)} I(X;T)-\beta I(T;Y).
-\]
+$$
 
 This expresses a compression-relevance trade-off:
 
-- \(I(X;T)\) penalizes how much raw input detail the representation keeps
-- \(I(T;Y)\) rewards how much target-relevant information survives
+- $I(X;T)$ penalizes how much raw input detail the representation keeps
+- $I(T;Y)$ rewards how much target-relevant information survives
 
 At a conceptual level, this is one of the cleanest mathematical statements of what a useful representation should do.
 
@@ -1194,7 +1194,7 @@ Interpretation:
 
 ### 7.1 Information Gain and Feature Selection
 
-If \(Y\) is the label and \(X_j\) is a feature, then \(I(X_j;Y)\) measures how much label uncertainty is reduced by observing that feature.
+If $Y$ is the label and $X_j$ is a feature, then $I(X_j;Y)$ measures how much label uncertainty is reduced by observing that feature.
 
 This is the basis of:
 
@@ -1274,16 +1274,16 @@ audit of representation quality.
 
 In active learning, the learner chooses which example to label next. A natural acquisition score is the expected information gain:
 
-\[
+$$
 I(Y;\Theta \mid X,\mathcal{D}),
-\]
+$$
 
 where:
 
-- \(X\) is the candidate query
-- \(Y\) is its unknown label
-- \(\Theta\) denotes model parameters or latent predictive state
-- \(\mathcal{D}\) is the current dataset
+- $X$ is the candidate query
+- $Y$ is its unknown label
+- $\Theta$ denotes model parameters or latent predictive state
+- $\mathcal{D}$ is the current dataset
 
 This quantity asks:
 
@@ -1311,7 +1311,7 @@ behavior more broadly.
 | 5 | "InfoNCE equals mutual information." | InfoNCE is a lower bound whose tightness depends on sampling and critic quality. | Say "MI-inspired lower bound" unless you have a proof of exact equality in your setting. |
 | 6 | "Large estimated MI always means the representation is better." | MI estimators can be biased and may reward nuisance information if the objective is misspecified. | Match the estimator and objective to the downstream task. |
 | 7 | "Mutual information always increases with better prediction." | Not necessarily in finite-sample estimates, and not for arbitrary surrogate objectives. | Separate theorem-level MI identities from estimator behavior. |
-| 8 | "Conditional MI is just MI with more variables." | Conditioning can reverse dependence patterns through common-cause or collider structure. | Interpret \(I(X;Y\mid Z)\) as residual dependence after accounting for \(Z\). |
+| 8 | "Conditional MI is just MI with more variables." | Conditioning can reverse dependence patterns through common-cause or collider structure. | Interpret $I(X;Y\mid Z)$ as residual dependence after accounting for $Z$. |
 | 9 | "Data processing says useful learned features are impossible." | DPI says processing cannot create information about the source, not that representation learning is useless. | Use it as a conservation law: preserve what matters, discard what does not. |
 | 10 | "Zero MI is easy to estimate from samples." | In high dimensions, estimating near-zero dependence can be very unstable. | Use caution with finite-sample estimators and report estimator details. |
 | 11 | "More negatives in contrastive learning always means exact MI recovery." | More negatives can tighten InfoNCE-style bounds, but optimization, batch size, and model class still matter. | Treat contrastive objectives as practical surrogates, not exact estimators by default. |
@@ -1322,25 +1322,25 @@ behavior more broadly.
 ## 9. Exercises
 
 1. **Exercise 1 (★): Tabular Mutual Information**
-   Given a \(2\times 2\) joint probability table, compute \(I(X;Y)\) directly from the definition and verify symmetry.
+   Given a $2\times 2$ joint probability table, compute $I(X;Y)$ directly from the definition and verify symmetry.
 
 2. **Exercise 2 (★): Zero Correlation, Positive MI**
    Construct a nonlinear example with zero covariance but positive mutual information, and explain why the difference arises.
 
 3. **Exercise 3 (★): MI as KL Divergence**
-   Starting from \(I(X;Y)=H(X)+H(Y)-H(X,Y)\), derive the KL form \(D_{\mathrm{KL}}(p_{XY}\|p_Xp_Y)\).
+   Starting from $I(X;Y)=H(X)+H(Y)-H(X,Y)$, derive the KL form $D_{\mathrm{KL}}(p_{XY} \Vert p_X p_Y)$.
 
 4. **Exercise 4 (★★): Chain Rule and Conditional MI**
-   Prove a chain rule such as \(I(X,Z;Y)=I(X;Y)+I(Z;Y\mid X)\), then interpret it in a feature-selection setting.
+   Prove a chain rule such as $I(X,Z;Y)=I(X;Y)+I(Z;Y\mid X)$, then interpret it in a feature-selection setting.
 
 5. **Exercise 5 (★★): Binary Symmetric Channel**
-   Compute the mutual information of a BSC numerically as a function of flip probability \(\varepsilon\), and recover the formula \(1-h_2(\varepsilon)\) for uniform input.
+   Compute the mutual information of a BSC numerically as a function of flip probability $\varepsilon$, and recover the formula $1-h_2(\varepsilon)$ for uniform input.
 
 6. **Exercise 6 (★★): Estimating MI from Samples**
    Generate dependent and independent synthetic datasets, estimate MI using a simple classical estimator, and analyze estimator bias and variance.
 
 7. **Exercise 7 (★★★): InfoNCE Lower Bound**
-   Derive the \(\log K - \mathcal{L}_{\mathrm{InfoNCE}}\) lower-bound form and explain what changes as the number of negatives grows.
+   Derive the $\log K - \mathcal{L}_{\mathrm{InfoNCE}}$ lower-bound form and explain what changes as the number of negatives grows.
 
 8. **Exercise 8 (★★★): MI in Modern ML**
    Choose one of feature selection, CLIP-style alignment, information bottleneck, or active learning and formulate the exact mutual-information quantity that the system is trying to maximize or preserve.

--- a/09-Information-Theory/03-Mutual-Information/theory.ipynb
+++ b/09-Information-Theory/03-Mutual-Information/theory.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3b71ab1a",
    "metadata": {},
    "source": [
     "# Mutual Information -- Theory Notebook\n",
@@ -23,6 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "c70f5daa",
    "metadata": {},
    "outputs": [
     {
@@ -69,6 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "b670c713",
    "metadata": {},
    "outputs": [
     {
@@ -142,6 +145,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c097ac03",
    "metadata": {},
    "source": [
     "---\n",
@@ -154,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "60f2de41",
    "metadata": {},
    "outputs": [
     {
@@ -215,6 +220,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4d5dad0f",
    "metadata": {},
    "source": [
     "---\n",
@@ -227,6 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "73826968",
    "metadata": {},
    "outputs": [
     {
@@ -267,6 +274,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90ec3116",
    "metadata": {},
    "source": [
     "---\n",
@@ -283,6 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "f11a0f2a",
    "metadata": {},
    "outputs": [
     {
@@ -314,6 +323,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "443c694f",
    "metadata": {},
    "source": [
     "---\n",
@@ -326,6 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "83f2f932",
    "metadata": {},
    "outputs": [
     {
@@ -365,6 +376,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "101006b6",
    "metadata": {},
    "source": [
     "---\n",
@@ -380,6 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "2e67c9b0",
    "metadata": {},
    "outputs": [
     {
@@ -433,6 +446,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "24d37616",
    "metadata": {},
    "source": [
     "---\n",
@@ -449,6 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "2c85bb68",
    "metadata": {},
    "outputs": [
     {
@@ -480,6 +495,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "78b4c5c4",
    "metadata": {},
    "source": [
     "---\n",
@@ -496,6 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "7e59573d",
    "metadata": {},
    "outputs": [
     {
@@ -546,6 +563,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "895e7687",
    "metadata": {},
    "source": [
     "---\n",
@@ -558,6 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "bdd46b44",
    "metadata": {},
    "outputs": [
     {
@@ -596,6 +615,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9dddf151",
    "metadata": {},
    "source": [
     "---\n",
@@ -608,6 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "98a9a1ac",
    "metadata": {},
    "outputs": [
     {
@@ -647,6 +668,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7b615c96",
    "metadata": {},
    "source": [
     "---\n",
@@ -659,6 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "4dda87c6",
    "metadata": {},
    "outputs": [
     {
@@ -701,6 +724,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a66f1caa",
    "metadata": {},
    "source": [
     "---\n",
@@ -713,6 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "724e6ad7",
    "metadata": {},
    "outputs": [
     {
@@ -760,6 +785,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "814eca9d",
    "metadata": {},
    "source": [
     "---\n",
@@ -776,6 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "38941332",
    "metadata": {},
    "outputs": [
     {
@@ -806,8 +833,7 @@
     "    fig, ax = plt.subplots()\n",
     "    ax.plot(rhos, mi_closed, color=COLORS['secondary'])\n",
     "    ax.set_title('Mutual information for correlated Gaussians')\n",
-    "    ax.set_xlabel('Correlation $\n",
-    "ho$')\n",
+    "    ax.set_xlabel('Correlation $\\\\rho$')\n",
     "    ax.set_ylabel('$I(X;Y)$ (nats)')\n",
     "    fig.tight_layout()\n",
     "    plt.show()\n",
@@ -816,6 +842,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77eed50d",
    "metadata": {},
    "source": [
     "---\n",
@@ -828,6 +855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "650833d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -855,6 +883,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "395b7a14",
    "metadata": {},
    "source": [
     "---\n",
@@ -867,6 +896,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e84c53a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -891,6 +921,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0afb8e1a",
    "metadata": {},
    "source": [
     "---\n",
@@ -903,6 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b395d58b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,6 +957,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cdc00276",
    "metadata": {},
    "source": [
     "---\n",
@@ -937,6 +970,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6a4160a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,6 +1006,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5b74e6a6",
    "metadata": {},
    "source": [
     "---\n",
@@ -984,6 +1019,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c4aa2dab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,6 +1062,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bd973e04",
    "metadata": {},
    "source": [
     "---\n",
@@ -1038,6 +1075,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "81d23f0a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1073,6 +1111,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09accedb",
    "metadata": {},
    "source": [
     "---\n",
@@ -1085,6 +1124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59840160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,6 +1153,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b6d2d007",
    "metadata": {},
    "source": [
     "---\n",
@@ -1125,6 +1166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "197ced31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1151,6 +1193,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a173814c",
    "metadata": {},
    "source": [
     "---\n",
@@ -1163,6 +1206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cc4aa167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1196,6 +1240,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1b66dad1",
    "metadata": {},
    "source": [
     "---\n",
@@ -1208,6 +1253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0d9c13f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1235,6 +1281,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9c6b8db",
    "metadata": {},
    "source": [
     "---\n",
@@ -1247,6 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "25bca0fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,13 +1319,13 @@
     "for name, cond in checks.items():\n",
     "    print(f\"{'PASS' if cond else 'FAIL'} — {name}\")\n",
     "\n",
-    "print(f'\n",
-    "Example MI value: {mi:.6f} nats')\n",
+    "print(f'\\\\nExample MI value: {mi:.6f} nats')\n",
     "print('Notebook complete. Next: use exercises.ipynb to practice the identities and applications.')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1faf439c",
    "metadata": {},
    "source": [
     "---\n",


### PR DESCRIPTION
## Summary

- Repair `09-Information-Theory/03-Mutual-Information/notes.md` math formatting to use LaTeX-in-Markdown delimiters.
- Keep the Mutual Information theory and exercise notebooks runnable after the serialization fixes.
- Leave unrelated local work out of the branch.

## Validation

- `MPLBACKEND=Agg .venv/bin/python` executed both Mutual Information notebooks with `nbclient`.
- `git diff --check` passed for the staged Mutual Information files.
