### PR TITLE
[codex] Add adaptive learning rate section

### DIFF
--- a/08-Optimization/06-Optimization-Landscape/exercises.ipynb
+++ b/08-Optimization/06-Optimization-Landscape/exercises.ipynb
@@ -1,0 +1,521 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Optimization Landscape \u2014 Exercises\n",
+        "\n",
+        "This notebook contains 8 exercises covering critical-point classification, Hessian spectra, symmetry, overparameterization, sharpness, interpolation barriers, edge-of-stability intuition, and practical landscape diagnosis.\n",
+        "\n",
+        "**Difficulty:** Exercises 1-3 are mechanical, 4-6 are conceptual/theoretical, and 7-8 are applied ML interpretation exercises.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_close(name, value, target, tol=1e-8):\n",
+        "    ok = np.allclose(value, target, atol=tol, rtol=tol)\n",
+        "    print(f\"{'PASS' if ok else 'FAIL'} - {name}\")\n",
+        "    if not ok:\n",
+        "        print(\"  value :\", value)\n",
+        "        print(\"  target:\", target)\n",
+        "    return ok\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "def loss_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return 0.5 * (u * v - 1.0) ** 2\n",
+        "\n",
+        "def hess_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return np.array([\n",
+        "        [v**2, 2 * u * v - 1.0],\n",
+        "        [2 * u * v - 1.0, u**2],\n",
+        "    ], dtype=float)\n",
+        "\n",
+        "def line_path(a, b, ts):\n",
+        "    return np.array([(1 - t) * np.array(a) + t * np.array(b) for t in ts])\n",
+        "\n",
+        "def path_barrier(path, loss_fn):\n",
+        "    vals = np.array([loss_fn(p) for p in path])\n",
+        "    return vals.max() - max(vals[0], vals[-1]), vals\n",
+        "\n",
+        "print(\"Exercise helpers ready.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 1 [*] \u2014 Classify a saddle and a minimum\n",
+        "\n",
+        "For the objective\n",
+        "\n",
+        "$$\n",
+        "\\mathcal{L}(u,v) = \\frac{1}{2}(uv - 1)^2,\n",
+        "$$\n",
+        "\n",
+        "classify the points $(0,0)$ and $(1,1)$ using the Hessian eigenvalues.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 1: Your Solution\n",
+        "theta_s = np.array([0.0, 0.0])\n",
+        "theta_m = np.array([1.0, 1.0])\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 1: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "def hess_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return np.array([\n",
+        "        [v**2, 2 * u * v - 1.0],\n",
+        "        [2 * u * v - 1.0, u**2],\n",
+        "    ], dtype=float)\n",
+        "\n",
+        "header(\"Exercise 1\")\n",
+        "eig_s = np.linalg.eigvalsh(hess_uv(np.array([0.0, 0.0])))\n",
+        "eig_m = np.linalg.eigvalsh(hess_uv(np.array([1.0, 1.0])))\n",
+        "print(\"Saddle eigenvalues :\", eig_s)\n",
+        "print(\"Minimum eigenvalues:\", eig_m)\n",
+        "check_true(\"Origin is a strict saddle\", eig_s[0] < 0 < eig_s[1])\n",
+        "check_true(\"(1,1) is a degenerate minimum\", eig_m[0] >= -1e-12 and eig_m[1] > 0)\n",
+        "print(\"\\nTakeaway: the same loss can contain both negative-curvature saddles and flat minima.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 2 [*] \u2014 Hessian signature\n",
+        "\n",
+        "Let\n",
+        "\n",
+        "$$\n",
+        "H =\n",
+        "\\begin{bmatrix}\n",
+        "3 & 1 \\\\\n",
+        "1 & -2\n",
+        "\\end{bmatrix}.\n",
+        "$$\n",
+        "\n",
+        "Compute its eigenvalues and decide whether it corresponds locally to a minimum, maximum, or saddle.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 2: Your Solution\n",
+        "H = np.array([[3.0, 1.0], [1.0, -2.0]])\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 2: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "header(\"Exercise 2\")\n",
+        "H = np.array([[3.0, 1.0], [1.0, -2.0]])\n",
+        "eigs = np.linalg.eigvalsh(H)\n",
+        "print(\"Eigenvalues:\", eigs)\n",
+        "check_true(\"Mixed-sign spectrum implies a saddle\", eigs[0] < 0 < eigs[1])\n",
+        "print(\"\\nTakeaway: Hessian signs classify local geometry much more strongly than gradient norm alone.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 3 [*] \u2014 Symmetry-preserving rescaling\n",
+        "\n",
+        "Show numerically that the points $(1,1)$ and $(3,\\frac{1}{3})$ define the same scalar function under the model $x \\mapsto uvx$.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 3: Your Solution\n",
+        "xs = np.linspace(-2, 2, 20)\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 3: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_close(name, value, target, tol=1e-8):\n",
+        "    ok = np.allclose(value, target, atol=tol, rtol=tol)\n",
+        "    print(f\"{'PASS' if ok else 'FAIL'} - {name}\")\n",
+        "    return ok\n",
+        "\n",
+        "header(\"Exercise 3\")\n",
+        "xs = np.linspace(-2, 2, 20)\n",
+        "y1 = (1.0 * 1.0) * xs\n",
+        "y2 = (3.0 * (1.0 / 3.0)) * xs\n",
+        "check_close(\"Outputs agree on all sampled inputs\", y1, y2)\n",
+        "print(\"\\nTakeaway: parameter-space distance can hide exact function-space equivalence.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 4 [**] \u2014 Interpolation barrier\n",
+        "\n",
+        "Measure the straight-line interpolation barrier between $(0.5,2)$ and $(2,0.5)$ for the loss\n",
+        "\n",
+        "$$\n",
+        "\\mathcal{L}(u,v) = \\frac{1}{2}(uv - 1)^2.\n",
+        "$$\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 4: Your Solution\n",
+        "theta_a = np.array([0.5, 2.0])\n",
+        "theta_b = np.array([2.0, 0.5])\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 4: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "def loss_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return 0.5 * (u * v - 1.0) ** 2\n",
+        "\n",
+        "header(\"Exercise 4\")\n",
+        "theta_a = np.array([0.5, 2.0])\n",
+        "theta_b = np.array([2.0, 0.5])\n",
+        "ts = np.linspace(0, 1, 401)\n",
+        "path = np.array([(1 - t) * theta_a + t * theta_b for t in ts])\n",
+        "vals = np.array([loss_uv(p) for p in path])\n",
+        "barrier = vals.max() - max(vals[0], vals[-1])\n",
+        "print(\"Barrier =\", barrier)\n",
+        "check_true(\"The straight line rises above zero\", barrier > 0.05)\n",
+        "print(\"\\nTakeaway: a linear barrier does not rule out a nonlinear low-loss connection.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 5 [**] \u2014 Overparameterized minimum\n",
+        "\n",
+        "For\n",
+        "\n",
+        "$$\n",
+        "\\mathcal{L}(a,b,c) = \\frac{1}{2}(abc - 1)^2,\n",
+        "$$\n",
+        "\n",
+        "explain why a point with $abc=1$ should have at least two flat directions.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 5: Your Solution\n",
+        "H_guess = np.ones((3, 3))\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 5: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "header(\"Exercise 5\")\n",
+        "H = np.ones((3, 3))\n",
+        "eigs = np.linalg.eigvalsh(H)\n",
+        "print(\"Eigenvalues:\", eigs)\n",
+        "check_true(\"Two eigenvalues are zero\", np.sum(np.abs(eigs) < 1e-12) == 2)\n",
+        "print(\"\\nTakeaway: one scalar constraint on three parameters leaves a two-dimensional solution manifold.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 6 [**] \u2014 Sharpness caveat\n",
+        "\n",
+        "Compare the top Hessian eigenvalue at $(1,1)$ and $(3,\\frac{1}{3})$. What does the comparison say about naive flatness claims?\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 6: Your Solution\n",
+        "theta_bal = np.array([1.0, 1.0])\n",
+        "theta_unbal = np.array([3.0, 1.0 / 3.0])\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 6: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "def hess_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return np.array([\n",
+        "        [v**2, 2 * u * v - 1.0],\n",
+        "        [2 * u * v - 1.0, u**2],\n",
+        "    ], dtype=float)\n",
+        "\n",
+        "header(\"Exercise 6\")\n",
+        "lam_bal = np.max(np.linalg.eigvalsh(hess_uv(np.array([1.0, 1.0]))))\n",
+        "lam_unbal = np.max(np.linalg.eigvalsh(hess_uv(np.array([3.0, 1.0 / 3.0]))))\n",
+        "print(\"lambda_max balanced  =\", lam_bal)\n",
+        "print(\"lambda_max unbalanced=\", lam_unbal)\n",
+        "check_true(\"Same function can have different raw sharpness\", lam_unbal > lam_bal * 2)\n",
+        "print(\"\\nTakeaway: raw parameter-space sharpness is not invariant under function-preserving reparameterization.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 7 [***] \u2014 Stability threshold\n",
+        "\n",
+        "For the quadratic loss\n",
+        "\n",
+        "$$\n",
+        "f(\\boldsymbol{\\theta}) = \\frac{1}{2}\\boldsymbol{\\theta}^\\top\n",
+        "\\begin{bmatrix}\n",
+        "1 & 0 \\\\\n",
+        "0 & 10\n",
+        "\\end{bmatrix}\n",
+        "\\boldsymbol{\\theta},\n",
+        "$$\n",
+        "\n",
+        "what is the largest stable learning rate for plain gradient descent?\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 7: Your Solution\n",
+        "H = np.diag([1.0, 10.0])\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 7: Solution\n",
+        "import numpy as np\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_close(name, value, target, tol=1e-8):\n",
+        "    ok = np.allclose(value, target, atol=tol, rtol=tol)\n",
+        "    print(f\"{'PASS' if ok else 'FAIL'} - {name}\")\n",
+        "    return ok\n",
+        "\n",
+        "header(\"Exercise 7\")\n",
+        "H = np.diag([1.0, 10.0])\n",
+        "eta_max = 2.0 / np.max(np.diag(H))\n",
+        "print(\"Largest stability threshold =\", eta_max)\n",
+        "check_close(\"eta_max = 2/lambda_max\", eta_max, 0.2)\n",
+        "print(\"\\nTakeaway: top curvature sets the tightest local stability limit for quadratic GD.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Exercise 8 [***] \u2014 Landscape-aware checkpoint averaging\n",
+        "\n",
+        "Explain, in practical ML terms, when checkpoint averaging should help and when it should fail.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 8: Your Solution\n",
+        "pass\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Exercise 8: Solution\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "header(\"Exercise 8\")\n",
+        "print(\"Averaging helps when checkpoints lie in a compatible low-loss corridor or connected region.\")\n",
+        "print(\"It fails when checkpoints are separated by symmetry mismatch, task mismatch, or high barriers.\")\n",
+        "check_true(\"A correct answer mentions both geometry and compatibility\", True)\n",
+        "print(\"\\nTakeaway: averaging is a geometric assumption about the relationship between the checkpoints, not a free lunch.\")\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/08-Optimization/06-Optimization-Landscape/notes.md
+++ b/08-Optimization/06-Optimization-Landscape/notes.md
@@ -1,0 +1,1434 @@
+[← Back to Optimization](../README.md) | [Next: Adaptive Learning Rate →](../07-Adaptive-Learning-Rate/notes.md)
+
+---
+
+# Optimization Landscape
+
+> _"Optimization is not only about the algorithm you run. It is also about the shape of the world that algorithm is moving through."_
+
+## Overview
+
+Modern deep learning solves nonconvex optimization problems with far more parameters than data constraints, yet training usually works. That fact is strange if your mental model of nonconvex optimization is "millions of bad local minima." The point of optimization-landscape analysis is to replace that cartoon with something closer to reality: high-dimensional neural losses are full of symmetry, degeneracy, wide flat regions, low-rank curvature structure, and surprisingly connected sets of good solutions.
+
+This section studies the geometry of those losses. We will describe critical points, saddle points, Hessian spectra, sharpness and flatness, mode connectivity, interpolation paths, and the role of overparameterization. Some of these ideas are mathematically precise; others are useful heuristics that must be handled carefully. A large part of becoming strong in optimization for AI is learning which claims are theorems, which are empirical regularities, and which are tempting but unreliable stories.
+
+The section sits between [Stochastic Optimization](../05-Stochastic-Optimization/notes.md) and the later practical sections on adaptive methods, regularization, and schedules. That placement matters. Once you know how SGD behaves and before you choose optimizer engineering tricks, you want a geometric picture of what the optimizer is actually traversing.
+
+This is also one of the most misunderstood topics in modern ML. Terms like "sharp minimum," "flat minimum," and "good basin" are often used loosely. We will keep the useful intuitions, but we will repeatedly mark where those intuitions break down under reparameterization, scale symmetry, and function-space equivalence.
+
+**Scope note.** This section is the canonical home for the geometry of nonconvex objectives in this chapter. The _algorithms_ for deterministic first-order optimization are covered in [Gradient Descent](../02-Gradient-Descent/notes.md). Curvature-aware updates and Hessian-based methods belong to [Second-Order Methods](../03-Second-Order-Methods/notes.md). Gradient noise, batch size, and stochastic dynamics are treated systematically in [Stochastic Optimization](../05-Stochastic-Optimization/notes.md). Here the focus is the terrain itself: what kind of surface is being optimized, and what can that geometry explain about training and generalization?
+
+## Prerequisites
+
+- **Convexity and strong convexity** — especially the contrast between convex and nonconvex geometry — [Convex Optimization](../01-Convex-Optimization/notes.md)
+- **Gradient descent and momentum** — update dynamics, stability, and convergence language — [Gradient Descent](../02-Gradient-Descent/notes.md)
+- **Hessians, eigenvalues, and Newton-style curvature reasoning** — [Second-Order Methods](../03-Second-Order-Methods/notes.md)
+- **Stochastic gradients, batch size, and noise** — [Stochastic Optimization](../05-Stochastic-Optimization/notes.md)
+- **Matrix spectra and positive semidefinite matrices** — [Eigenvalues and Eigenvectors](../../03-Advanced-Linear-Algebra/01-Eigenvalues-and-Eigenvectors/notes.md) and [Positive Definite Matrices](../../03-Advanced-Linear-Algebra/07-Positive-Definite-Matrices/notes.md)
+
+## Companion Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [theory.ipynb](theory.ipynb) | Interactive experiments on saddles, Hessian spectra, sharpness, interpolation paths, and mode connectivity |
+| [exercises.ipynb](exercises.ipynb) | 8 graded exercises on critical points, curvature, symmetries, connectivity, and landscape diagnostics |
+
+## Learning Objectives
+
+After completing this section, you will:
+
+1. Distinguish convex and nonconvex optimization landscapes in a mathematically precise way
+2. Classify critical points using gradients and Hessian eigenvalues
+3. Explain why saddle points and flat directions dominate high-dimensional nonconvex problems
+4. Interpret Hessian spectra as practical diagnostics of local landscape geometry
+5. Describe how symmetry and overparameterization create families of equivalent minima
+6. Explain why naive "flat minima generalize better" stories need reparameterization caveats
+7. Understand sharpness measures, their uses, and their limitations
+8. Interpret linear interpolation and mode-connectivity experiments without overreading them
+9. Connect landscape geometry to batch size, stability, and optimizer behavior
+10. Explain why parameter-space distance and function-space distance can disagree
+11. Use landscape ideas to reason about residual networks, fine-tuning, checkpoint averaging, and large-batch training
+12. Separate stable theory from current empirical heuristics in 2026-era deep learning practice
+
+---
+
+## Table of Contents
+
+- [1. Intuition](#1-intuition)
+  - [1.1 Why Optimization Landscape Matters](#11-why-optimization-landscape-matters)
+  - [1.2 Convex vs Nonconvex Terrain](#12-convex-vs-nonconvex-terrain)
+  - [1.3 Why High Dimension Changes the Story](#13-why-high-dimension-changes-the-story)
+  - [1.4 Historical Timeline](#14-historical-timeline)
+  - [1.5 Why This Matters for AI](#15-why-this-matters-for-ai)
+- [2. Formal Definitions](#2-formal-definitions)
+  - [2.1 Objective Functions, Parameter Space, and Trajectories](#21-objective-functions-parameter-space-and-trajectories)
+  - [2.2 Critical Points](#22-critical-points)
+  - [2.3 Hessian, Spectrum, and Curvature](#23-hessian-spectrum-and-curvature)
+  - [2.4 Basins, Barriers, Sharpness, and Flatness](#24-basins-barriers-sharpness-and-flatness)
+  - [2.5 Parameter Space vs Function Space](#25-parameter-space-vs-function-space)
+- [3. Core Theory I: Critical Points and Local Geometry](#3-core-theory-i-critical-points-and-local-geometry)
+  - [3.1 First- and Second-Order Tests](#31-first--and-second-order-tests)
+  - [3.2 Saddle Points in High Dimension](#32-saddle-points-in-high-dimension)
+  - [3.3 Degeneracy, Plateaus, and Flat Directions](#33-degeneracy-plateaus-and-flat-directions)
+  - [3.4 Strict-Saddle Intuition and Escape Mechanisms](#34-strict-saddle-intuition-and-escape-mechanisms)
+  - [3.5 Hessian Spectrum as a Diagnostic](#35-hessian-spectrum-as-a-diagnostic)
+- [4. Core Theory II: Symmetry, Overparameterization, and Minima Structure](#4-core-theory-ii-symmetry-overparameterization-and-minima-structure)
+  - [4.1 Permutation and Scaling Symmetries](#41-permutation-and-scaling-symmetries)
+  - [4.2 Overparameterization and Manifolds of Minima](#42-overparameterization-and-manifolds-of-minima)
+  - [4.3 Deep Linear Networks as a Tractable Model](#43-deep-linear-networks-as-a-tractable-model)
+  - [4.4 Interpolation Regime and Zero-Training-Loss Sets](#44-interpolation-regime-and-zero-training-loss-sets)
+  - [4.5 Parameter Distance vs Functional Distance](#45-parameter-distance-vs-functional-distance)
+- [5. Core Theory III: Sharpness, Flatness, and Generalization](#5-core-theory-iii-sharpness-flatness-and-generalization)
+  - [5.1 What Sharpness Measures](#51-what-sharpness-measures)
+  - [5.2 Flat Minima Intuition](#52-flat-minima-intuition)
+  - [5.3 Reparameterization Caveats](#53-reparameterization-caveats)
+  - [5.4 Batch Size, Noise, and Sharpness](#54-batch-size-noise-and-sharpness)
+  - [5.5 What We Can Honestly Say About Generalization](#55-what-we-can-honestly-say-about-generalization)
+- [6. Core Theory IV: Connectivity, Visualization, and Training Paths](#6-core-theory-iv-connectivity-visualization-and-training-paths)
+  - [6.1 Linear Interpolation from Initialization to Solution](#61-linear-interpolation-from-initialization-to-solution)
+  - [6.2 Meaningful Loss-Surface Visualization](#62-meaningful-loss-surface-visualization)
+  - [6.3 Mode Connectivity](#63-mode-connectivity)
+  - [6.4 Training Trajectories and Barrier Crossing](#64-training-trajectories-and-barrier-crossing)
+  - [6.5 SWA, Model Soups, and Connectivity Exploitation](#65-swa-model-soups-and-connectivity-exploitation)
+- [7. Advanced Topics](#7-advanced-topics)
+  - [7.1 Random-Matrix and Spectral Heuristics](#71-random-matrix-and-spectral-heuristics)
+  - [7.2 Edge of Stability and Catapult Dynamics](#72-edge-of-stability-and-catapult-dynamics)
+  - [7.3 Landscape-Aware Objectives](#73-landscape-aware-objectives)
+  - [7.4 Function-Space Flatness and PAC-Bayes-Flavored Views](#74-function-space-flatness-and-pac-bayes-flavored-views)
+  - [7.5 Open Problems for Frontier Models](#75-open-problems-for-frontier-models)
+- [8. Applications in Machine Learning](#8-applications-in-machine-learning)
+  - [8.1 Why Residual Connections Help](#81-why-residual-connections-help)
+  - [8.2 Diagnosing Training Instability](#82-diagnosing-training-instability)
+  - [8.3 Large-Batch Training and Generalization Gaps](#83-large-batch-training-and-generalization-gaps)
+  - [8.4 Fine-Tuning, LoRA, and Low-Dimensional Updates](#84-fine-tuning-lora-and-low-dimensional-updates)
+  - [8.5 Ensembles, Averaging, and Checkpoint Merging](#85-ensembles-averaging-and-checkpoint-merging)
+- [9. Common Mistakes](#9-common-mistakes)
+- [10. Exercises](#10-exercises)
+- [11. Why This Matters for AI (2026 Perspective)](#11-why-this-matters-for-ai-2026-perspective)
+- [12. Conceptual Bridge](#12-conceptual-bridge)
+- [References](#references)
+
+---
+
+## 1. Intuition
+
+### 1.1 Why Optimization Landscape Matters
+
+When people first learn optimization for machine learning, the objective often looks simple:
+
+$$
+\min_{\boldsymbol{\theta} \in \mathbb{R}^p} \mathcal{L}(\boldsymbol{\theta}).
+$$
+
+But that one line hides nearly everything that makes modern deep learning strange. The loss $\mathcal{L}$ is usually nonconvex, extremely high-dimensional, heavily overparameterized, and defined by a composition of many nonlinear layers. So the success or failure of optimization is not only about the update rule. It is also about the geometry of the set of points that produce high loss, low loss, instability, robustness, or equivalent functions.
+
+Landscape analysis asks questions like:
+
+- Are bad local minima the main problem, or are saddle points more important?
+- Is the bottom of the loss really a single point, or a high-dimensional region?
+- Why do independently trained models often seem connectable by low-loss paths?
+- Why can large learning rates help for a while and then destabilize training?
+- Why do some architectures train easily while others produce pathological curvature?
+
+These are not philosophical questions. They directly affect:
+
+- optimizer choice
+- batch-size scaling
+- checkpoint averaging
+- fine-tuning stability
+- quantization robustness
+- distributed training behavior
+
+If you only know update rules and not the terrain, you are like someone memorizing steering actions without understanding the road.
+
+```text
+OPTIMIZATION = DYNAMICS + GEOMETRY
+==============================================================
+
+  Algorithm side                         Landscape side
+
+  learning rate eta                      curvature
+  momentum beta                          barriers / valleys
+  batch size B                           saddle structure
+  preconditioner P                       sharp vs flat regions
+  schedule eta_t                         connected low-loss sets
+
+            Training behavior emerges from both together.
+==============================================================
+```
+
+### 1.2 Convex vs Nonconvex Terrain
+
+In a convex problem, the geometry is globally well-behaved. Every local minimum is global, line segments between feasible points stay inside the feasible region, and the curvature never creates deceptive basins. That is why convex optimization is the chapter foundation in [Convex Optimization](../01-Convex-Optimization/notes.md).
+
+Neural-network training is not like that. The parameterization itself introduces nonlinear interactions between layers, symmetries between neurons, and scaling freedoms that make the objective nonconvex. Even when the final function class has nice behavior, the parameter-space objective may have many critical points and enormous degeneracy.
+
+However, "nonconvex" does **not** mean "hopeless." That is one of the core lessons of this section. Modern deep-learning landscapes are not generic worst-case nonconvex functions. They often have:
+
+- broad families of equivalent solutions
+- many directions with near-zero curvature
+- structured rather than arbitrary Hessian spectra
+- low-loss tunnels between solutions
+- optimization trajectories that avoid the worst apparent obstacles
+
+So the correct contrast is not:
+
+- convex = easy
+- nonconvex = impossible
+
+Instead it is:
+
+- convex = globally structured and certifiable
+- deep nonconvex = locally complicated but empirically organized by symmetry, overparameterization, and stochastic dynamics
+
+```text
+CONVEX VS DEEP NONCONVEX
+==============================================================
+
+  Convex bowl                     Deep-network landscape
+
+          .                                  .   .   .
+       .     .                         ___--'--_     _--__
+     .    *    .                    _-'         '-_-'     '-_
+       .     .                     /    flat-ish   saddle     \
+          .                       |   valley     region       |
+
+  one basin                         many parameterizations
+  no spurious local minima          many saddles / flat directions
+  global guarantees                 rich local geometry
+==============================================================
+```
+
+### 1.3 Why High Dimension Changes the Story
+
+Our geometric intuition is usually two-dimensional: bowls, ridges, valleys, and isolated pits. But deep networks live in spaces of dimension $p$ where $p$ may be millions or billions. In such spaces, several low-dimensional intuitions fail badly.
+
+One especially important failure is the obsession with bad local minima. In high-dimensional nonconvex problems, stationary points with mixed positive and negative curvature directions can be far more common than isolated poor local minima. These are saddle points. They matter because gradient norms can become small there even though the point is not a solution worth keeping.
+
+Another failure is the idea that minima should be isolated. In overparameterized models, you often have many more free parameters than constraints imposed by the data. That means the set of solutions can become a manifold or at least a highly degenerate region, not a single sharply defined point.
+
+A third failure is the assumption that Euclidean distance in parameter space reflects functional difference. Two parameter vectors can be far apart while implementing nearly identical predictors because of permutation symmetry, scaling symmetry, or redundant parameterization.
+
+So high dimension changes the central questions. Instead of asking only "Where is the minimum?" we ask:
+
+- How many unstable directions does the Hessian have?
+- How many nearly flat directions are present?
+- Are low-loss points isolated or connected?
+- Does the optimizer operate near the stability boundary?
+- Which geometric quantities are invariant under reparameterization?
+
+### 1.4 Historical Timeline
+
+```text
+OPTIMIZATION-LANDSCAPE TIMELINE
+==============================================================
+
+  1997  Hochreiter & Schmidhuber
+        Flat minima proposed as a route to better generalization
+
+  2014  Dauphin et al.
+        Saddle points highlighted as a central obstacle in high dimension
+
+  2014  Goodfellow et al.
+        Linear interpolation studies suggest fewer severe barriers than expected
+
+  2017  Keskar et al.
+        Large-batch training linked to sharper minimizers and worse generalization
+
+  2017  Dinh et al.
+        Reparameterization caveats challenge naive flatness explanations
+
+  2017  Sagun et al.
+        Hessian spectra in deep nets show bulk-near-zero plus outlier structure
+
+  2018  Li et al.
+        Filter-normalized visualization sharpens loss-surface comparisons
+
+  2018  Garipov / Draxler et al.
+        Mode connectivity: low-loss paths between independently trained solutions
+
+  2021  Cohen et al.
+        Edge-of-stability dynamics observed during deep-network training
+
+  2022-2026
+        Landscape ideas inform SAM, SWA, model soups, low-rank adaptation,
+        scaling-law debugging, and large-model stability analysis
+==============================================================
+```
+
+### 1.5 Why This Matters for AI
+
+Optimization-landscape ideas matter for AI because large models are expensive enough that geometric misunderstandings become costly engineering mistakes.
+
+If you train a foundation model and the top Hessian eigenvalue explodes, the issue is not "optimization in general." It is local curvature and stability. If two fine-tuned checkpoints can be merged successfully, that is not magic; it is evidence about low-loss connectivity or at least functional proximity. If a residual architecture trains much more easily than a plain deep architecture, that is partly a landscape-shaping effect.
+
+Landscape language also helps unify several modern practices:
+
+- **small-batch SGD** as a geometry-sensitive sampler
+- **sharpness-aware methods** as local-flatness-seeking objectives
+- **SWA and soups** as practical exploitation of low-loss connected regions
+- **LoRA and low-rank fine-tuning** as evidence that useful adaptation often lies in surprisingly low-dimensional subspaces
+
+The big lesson is this: training success in modern AI is not explained by one theorem. It emerges from the interaction between overparameterization, architecture, stochasticity, curvature structure, and scale.
+
+---
+
+## 2. Formal Definitions
+
+### 2.1 Objective Functions, Parameter Space, and Trajectories
+
+Let $\boldsymbol{\theta} \in \mathbb{R}^p$ denote the trainable parameters of a model and let $\mathcal{L}(\boldsymbol{\theta})$ denote the training objective. The optimization landscape is the graph or geometric structure induced by $\mathcal{L}$ over parameter space.
+
+In supervised learning we commonly write
+
+$$
+\mathcal{L}(\boldsymbol{\theta}) = \frac{1}{n}\sum_{i=1}^n \ell\!\left(f_{\boldsymbol{\theta}}(\mathbf{x}^{(i)}), y^{(i)}\right) + \lambda R(\boldsymbol{\theta}),
+$$
+
+where:
+
+- $f_{\boldsymbol{\theta}}$ is the model
+- $\ell$ is the example-wise loss
+- $R$ is a regularizer
+- $\lambda \ge 0$ controls regularization strength
+
+An optimization algorithm generates a trajectory
+
+$$
+\boldsymbol{\theta}_0,\boldsymbol{\theta}_1,\ldots,\boldsymbol{\theta}_T
+$$
+
+according to some update rule such as gradient descent or SGD. Landscape questions can concern:
+
+- local geometry near one iterate
+- global relationships between two solutions
+- the entire path from initialization to convergence
+
+This distinction matters. A local Hessian tells you what the terrain looks like at one point. It says nothing by itself about the full geometry between distant solutions.
+
+### 2.2 Critical Points
+
+A point $\boldsymbol{\theta}^\star$ is a **critical point** or **stationary point** if
+
+$$
+\nabla \mathcal{L}(\boldsymbol{\theta}^\star) = \mathbf{0}.
+$$
+
+Critical points are classified as follows.
+
+- **Local minimum:** there exists $\varepsilon > 0$ such that $\mathcal{L}(\boldsymbol{\theta}^\star) \le \mathcal{L}(\boldsymbol{\theta})$ for all $\|\boldsymbol{\theta}-\boldsymbol{\theta}^\star\|_2 < \varepsilon$
+- **Strict local minimum:** the above inequality is strict for all $\boldsymbol{\theta} \neq \boldsymbol{\theta}^\star$ in that neighborhood
+- **Local maximum:** the analogous reversed inequality
+- **Saddle point:** a critical point that is neither a local minimum nor a local maximum
+
+In high-dimensional ML, strict local maxima are rarely the main story. Saddle points, flat saddles, and degenerate minima are much more relevant.
+
+### 2.3 Hessian, Spectrum, and Curvature
+
+The Hessian matrix at $\boldsymbol{\theta}$ is
+
+$$
+H(\boldsymbol{\theta}) = \nabla^2 \mathcal{L}(\boldsymbol{\theta}) \in \mathbb{R}^{p \times p}.
+$$
+
+For smooth scalar objectives, $H(\boldsymbol{\theta})$ is symmetric, so it admits an eigendecomposition
+
+$$
+H(\boldsymbol{\theta}) = Q \Lambda Q^\top,
+$$
+
+where $Q$ is orthogonal and $\Lambda = \operatorname{diag}(\lambda_1,\ldots,\lambda_p)$.
+
+The eigenvalues describe directional curvature:
+
+- $\lambda_i > 0$ means locally upward curvature along eigenvector $\mathbf{q}_i$
+- $\lambda_i < 0$ means locally downward curvature along $\mathbf{q}_i$
+- $\lambda_i \approx 0$ means a nearly flat direction
+
+This is the local second-order picture behind much of landscape analysis.
+
+Using the second-order Taylor expansion around $\boldsymbol{\theta}$,
+
+$$
+\mathcal{L}(\boldsymbol{\theta} + \mathbf{d})
+\approx
+\mathcal{L}(\boldsymbol{\theta})
+\;+\;
+\nabla \mathcal{L}(\boldsymbol{\theta})^\top \mathbf{d}
+\;+\;
+\frac{1}{2}\mathbf{d}^\top H(\boldsymbol{\theta})\mathbf{d}.
+$$
+
+At a critical point the linear term vanishes, so the Hessian dominates local behavior.
+
+### 2.4 Basins, Barriers, Sharpness, and Flatness
+
+These words are widely used, but they are not always used consistently.
+
+A **basin** is an informal term for a region of parameter space from which a particular optimization procedure tends to move toward the same solution or solution family. This is algorithm-dependent, not purely geometric.
+
+A **barrier** between two points $\boldsymbol{\theta}_a$ and $\boldsymbol{\theta}_b$ refers to a region along some path where the loss rises substantially above the endpoint losses. A typical path-based barrier proxy is
+
+$$
+\max_{t \in [0,1]} \mathcal{L}\big((1-t)\boldsymbol{\theta}_a + t\boldsymbol{\theta}_b\big)
+-
+\max\{\mathcal{L}(\boldsymbol{\theta}_a),\mathcal{L}(\boldsymbol{\theta}_b)\}.
+$$
+
+**Sharpness** informally measures how quickly loss increases when parameters are perturbed. One local definition is
+
+$$
+S_\rho(\boldsymbol{\theta})
+=
+\max_{\|\boldsymbol{\epsilon}\|_2 \le \rho}
+\big[
+\mathcal{L}(\boldsymbol{\theta}+\boldsymbol{\epsilon}) - \mathcal{L}(\boldsymbol{\theta})
+\big].
+$$
+
+**Flatness** informally means the opposite: perturbations within a neighborhood do not increase loss much.
+
+Important warning: these definitions depend on the chosen parameterization, norm, and perturbation scale. That is why naive claims about flat minima can be misleading.
+
+### 2.5 Parameter Space vs Function Space
+
+Two parameter vectors $\boldsymbol{\theta}$ and $\boldsymbol{\phi}$ can be:
+
+- far apart in parameter space
+- near-identical in function space
+
+Function-space closeness might mean, for example,
+
+$$
+\mathbb{E}_{\mathbf{x} \sim \mathcal{D}}
+\left[
+\|f_{\boldsymbol{\theta}}(\mathbf{x}) - f_{\boldsymbol{\phi}}(\mathbf{x})\|_2^2
+\right]
+\text{ is small.}
+$$
+
+This distinction is central in deep learning. Permuting hidden units or rescaling positively homogeneous layers can move you a long way in parameter space while leaving the implemented function unchanged or nearly unchanged.
+
+That is why many landscape observations become more meaningful when reframed in function space rather than raw parameter space.
+
+---
+
+## 3. Core Theory I: Critical Points and Local Geometry
+
+### 3.1 First- and Second-Order Tests
+
+For a differentiable objective, a necessary condition for a local optimum is
+
+$$
+\nabla \mathcal{L}(\boldsymbol{\theta}^\star) = \mathbf{0}.
+$$
+
+This condition alone is weak. A saddle point also satisfies it.
+
+The second-order test sharpens the picture:
+
+- if $H(\boldsymbol{\theta}^\star) \succ 0$, then $\boldsymbol{\theta}^\star$ is a strict local minimum
+- if $H(\boldsymbol{\theta}^\star) \prec 0$, then it is a strict local maximum
+- if $H(\boldsymbol{\theta}^\star)$ has both positive and negative eigenvalues, then it is a strict saddle
+
+When the Hessian is only positive semidefinite, things become subtler. The point may still be a local minimum, but the quadratic term does not settle all directions. Higher-order terms may matter.
+
+This is not a rare edge case in deep learning. In fact, near-zero eigenvalues are common because of overparameterization and symmetry.
+
+The classification logic can be summarized compactly:
+
+| Local Hessian signature | Geometric meaning | Typical optimization implication |
+| --- | --- | --- |
+| all eigenvalues $>0$ | strict local bowl | stable local minimum |
+| all eigenvalues $<0$ | strict local cap | unstable local maximum |
+| mixed signs | saddle | some descent directions still exist |
+| many near-zero eigenvalues | degenerate region | local model is flat or weakly constrained |
+
+For deep learning, the last two rows are usually far more relevant than the first two in their textbook forms.
+
+### 3.2 Saddle Points in High Dimension
+
+Dauphin et al. emphasized a critical idea for deep learning: in very high dimension, the real difficulty may come less from bad local minima and more from saddle points with many flat directions.
+
+Why? Suppose a stationary point has only a few negative-curvature directions and many positive or near-zero directions. Gradient descent can slow dramatically because the gradient is small, even though one or more directions still offer escape routes. In a large-dimensional parameter space, such mixed-curvature points can proliferate.
+
+This changes the optimization story:
+
+- bad local minima are not the only obstacle
+- near-stationary regions need not be good solutions
+- negative curvature detection can be more informative than loss alone
+
+From the Hessian perspective, a saddle point is diagnosed by at least one negative eigenvalue:
+
+$$
+\lambda_{\min}\!\big(H(\boldsymbol{\theta}^\star)\big) < 0.
+$$
+
+If that most negative eigenvalue is substantial in magnitude, there is a clear escape direction. If it is tiny, escape can be slow in practice.
+
+### 3.3 Degeneracy, Plateaus, and Flat Directions
+
+Many deep-network landscapes are not dominated by isolated, well-conditioned critical points. Instead they exhibit:
+
+- wide plateaus
+- nearly singular Hessians
+- many directions with $\lambda_i \approx 0$
+- continuous families of near-equivalent solutions
+
+These features are often called **degeneracy**. A degenerate minimum is one where the Hessian has one or more zero eigenvalues, so the quadratic approximation is flat in some directions.
+
+```text
+LOCAL GEOMETRY TYPES
+==============================================================
+
+  Well-conditioned minimum       Degenerate minimum
+
+          . . .                       ____________
+       .         .                 __/            \__
+     .      *      .              /      *          \
+       .         .                \__________________/
+          . . .
+
+  positive curvature all          many near-zero curvature directions
+  directions                      broad low-loss neighborhood
+
+  Strict saddle                   Plateau / nearly-flat region
+
+      \    /                      ----------------------------
+       \  /                       -----------*----------------
+        *                         ----------------------------
+       /  \
+      /    \
+
+  mixed signs in Hessian          tiny gradient, tiny curvature
+==============================================================
+```
+
+Flat directions matter in practice because they interact strongly with:
+
+- minibatch noise
+- learning-rate stability
+- checkpoint averaging
+- fine-tuning and merging
+
+They also make certain classical notions of local minima less informative than in low dimensions.
+
+### 3.4 Strict-Saddle Intuition and Escape Mechanisms
+
+There is a useful body of theory showing that for objectives satisfying a **strict-saddle property**, first-order methods with appropriate perturbations or stochasticity can avoid or escape saddles under suitable assumptions.
+
+The rough idea is:
+
+- if every non-minimum critical point has a direction of sufficiently negative curvature
+- and if the algorithm has either random initialization, injected noise, or stochastic gradient noise
+- then iterates are unlikely to converge to those saddles
+
+This is an important conceptual bridge, but it should be used carefully in deep learning. Real neural-network losses do not always fit cleanly into a neat strict-saddle theorem. Many practical saddles are highly degenerate rather than isolated. Some training dynamics are better described as moving along broad nearly-flat manifolds than escaping one clean unstable point.
+
+So the useful takeaway is not "the theorem explains all of deep learning." It is:
+
+- negative curvature matters
+- stochasticity helps
+- saddles are often easier to escape than sharp poor minima would be
+
+### 3.5 Hessian Spectrum as a Diagnostic
+
+A full Hessian matrix is too large to inspect directly in modern models, but its spectrum still provides a compact geometric summary.
+
+Common empirical observations in deep networks include:
+
+- a large bulk of eigenvalues near zero
+- a small number of positive outliers
+- occasional negative directions during parts of training
+
+This suggests a geometry with many flat directions and a few strongly curved task-relevant directions.
+
+Useful diagnostics include:
+
+- top eigenvalue $\lambda_{\max}(H)$ as a stability indicator
+- trace $\operatorname{tr}(H)$ as a coarse total-curvature proxy
+- spectral norm $\|H\|_2$
+- count of negative eigenvalues as a rough saddle indicator
+
+For example, step-size stability for simple gradient descent on a quadratic is governed by
+
+$$
+\eta < \frac{2}{\lambda_{\max}(H)}.
+$$
+
+This exact bound does not directly transfer unchanged to deep nets, but it motivates why top curvature directions are operationally important.
+
+> **Backward reference.**
+> The algorithmic side of Hessian use belongs to [Second-Order Methods](../03-Second-Order-Methods/notes.md). Here we care about the Hessian primarily as a geometric object rather than as something to invert.
+
+---
+
+## 4. Core Theory II: Symmetry, Overparameterization, and Minima Structure
+
+### 4.1 Permutation and Scaling Symmetries
+
+Neural networks are not unique parameterizations of their functions. This is one reason their landscapes differ so much from generic textbook nonconvex problems.
+
+**Permutation symmetry.** If a hidden layer has $m$ units, permuting those units and undoing the same permutation in the next layer leaves the realized function unchanged. So one functional solution corresponds to many parameter vectors.
+
+**Scaling symmetry.** In positively homogeneous networks such as ReLU networks, scaling the incoming weights of a unit by $c > 0$ and the outgoing weights by $1/c$ leaves the overall function unchanged:
+
+$$
+\sigma(cz) = c\sigma(z)
+\quad \text{for ReLU and } c > 0,
+$$
+
+so certain compensating rescalings preserve predictions.
+
+These symmetries create equivalence classes of parameters rather than isolated canonical solutions.
+
+```text
+SAME FUNCTION, MANY PARAMETERS
+==============================================================
+
+  theta_a  ---- permutation ---->  theta_b
+     |                                 |
+     |                                 |
+  same predictor                    same predictor
+     |                                 |
+     +------ scaling compensation -----+
+
+  Parameter space:
+      many points
+
+  Function space:
+      one behavior
+==============================================================
+```
+
+### 4.2 Overparameterization and Manifolds of Minima
+
+When the parameter dimension $p$ is much larger than the effective number of constraints imposed by the data, the set of zero-training-loss solutions can have positive dimension. Intuitively, there are more degrees of freedom than the task needs.
+
+That makes isolated minima less typical. Instead, one can obtain:
+
+- connected low-loss regions
+- manifolds of exact interpolating solutions
+- extensive flat directions tangent to the solution set
+
+In a local quadratic approximation, if $H(\boldsymbol{\theta}^\star)$ has many zero eigenvalues, the minimum may lie on or near a flat submanifold. This aligns with empirical Hessian spectra showing many nearly zero eigenvalues in overparameterized networks.
+
+The important implication is that "the optimizer found **the** minimum" is often the wrong sentence. A better sentence is: the optimizer found one point in a large region of parameters that achieve similarly low training loss.
+
+A useful local dimension heuristic comes from constraint counting. Suppose the training objective is nearly minimized when a set of effective constraints is satisfied, and suppose the Jacobian of those constraints has rank $r$ at the solution. Then the local solution set can behave like a manifold of dimension approximately
+
+$$
+p-r.
+$$
+
+This is only a heuristic and regularity assumptions matter, but it explains why increasing parameter count while holding data constraints fixed often produces more flat directions rather than isolated solutions.
+
+### 4.3 Deep Linear Networks as a Tractable Model
+
+Deep linear networks replace nonlinear activations by identities:
+
+$$
+f_{\boldsymbol{\theta}}(\mathbf{x}) = W_L W_{L-1}\cdots W_1 \mathbf{x}.
+$$
+
+Even though this model is nonlinear in the parameters, it is analytically much friendlier than a full nonlinear network. It has become a canonical toy model because it already exhibits:
+
+- nonconvex parameterization
+- symmetries
+- degenerate minima
+- structured saddle behavior
+
+Yet under common settings with squared loss, deep linear models often avoid bad local minima: critical points are either global minima or saddles. This provides a valuable counterexample to the naive claim that nonconvexity automatically implies many harmful local minima.
+
+Deep linear models do **not** prove that real deep nets are easy for the same reason. But they do show that parameter nonconvexity can coexist with benign optimization structure.
+
+There is also a practical pedagogical reason they matter. Many questions that are almost impossible to answer exactly for nonlinear networks become analyzable in deep linear models:
+
+- how depth changes critical-point structure
+- how symmetries create equivalent minima
+- how singular values govern convergence speed
+- why zero training loss can coexist with many factorizations
+
+So deep linear networks are not realistic models of modern AI systems, but they are excellent controlled experiments for isolating the geometry induced by parameterization alone.
+
+### 4.4 Interpolation Regime and Zero-Training-Loss Sets
+
+Modern large models often train in the **interpolation regime**, where the training loss can be driven extremely close to zero. In that regime, the geometry near the bottom changes qualitatively.
+
+If the dataset constraints can all be satisfied, then the loss minimum is not necessarily a single sharply defined parameter vector. The optimizer may instead land in one of many exact-fit solutions. Regularization, optimizer noise, initialization, architecture, and implicit bias then determine which member of that family is selected.
+
+This is one reason optimization and generalization cannot be cleanly separated. Once interpolation is easy, the real question is not "Can the network fit the data?" but "Which zero-loss or near-zero-loss solution will training dynamics prefer?"
+
+### 4.5 Parameter Distance vs Functional Distance
+
+Suppose we have two trained networks $\boldsymbol{\theta}_a$ and $\boldsymbol{\theta}_b$. A large Euclidean distance
+
+$$
+\|\boldsymbol{\theta}_a - \boldsymbol{\theta}_b\|_2
+$$
+
+does not imply they are functionally different. Conversely, a small parameter difference can matter if it aligns with a highly sensitive direction.
+
+This makes landscape interpretation difficult:
+
+- a high-loss barrier in parameter space might disappear after a symmetry-aware reparameterization
+- two checkpoints may be far apart in weights but close in outputs
+- flatness in parameter space may not correspond to robustness in function space
+
+That is why many modern analyses supplement parameter-space geometry with output-space or function-space metrics such as:
+
+$$
+\mathbb{E}_{\mathbf{x}\sim \mathcal{D}}
+\left[
+\|f_{\boldsymbol{\theta}_a}(\mathbf{x}) - f_{\boldsymbol{\theta}_b}(\mathbf{x})\|_2^2
+\right].
+$$
+
+This perspective becomes especially important for fine-tuning, merging, and ensembling.
+
+It also suggests a practical study habit: whenever a claim about geometry depends heavily on Euclidean distance in weights, immediately ask whether the same claim still sounds plausible in function space.
+
+---
+
+## 5. Core Theory III: Sharpness, Flatness, and Generalization
+
+### 5.1 What Sharpness Measures
+
+Sharpness is meant to capture how rapidly the loss rises around a parameter vector. In the simplest local picture, if the loss is well approximated by a quadratic near $\boldsymbol{\theta}$, then
+
+$$
+\mathcal{L}(\boldsymbol{\theta}+\boldsymbol{\epsilon})
+\approx
+\mathcal{L}(\boldsymbol{\theta})
++
+\nabla \mathcal{L}(\boldsymbol{\theta})^\top \boldsymbol{\epsilon}
++
+\frac{1}{2}\boldsymbol{\epsilon}^\top H(\boldsymbol{\theta})\boldsymbol{\epsilon}.
+$$
+
+Near a stationary point, the linear term vanishes, so local sharpness is controlled by the Hessian. In particular, the largest local curvature direction is determined by $\lambda_{\max}(H)$.
+
+This motivates several practical proxies:
+
+1. **Top-eigenvalue sharpness**
+   $$
+   S_{\max}(\boldsymbol{\theta}) \approx \lambda_{\max}(H(\boldsymbol{\theta})).
+   $$
+
+2. **Neighborhood max-loss sharpness**
+   $$
+   S_\rho(\boldsymbol{\theta})
+   =
+   \max_{\|\boldsymbol{\epsilon}\|_2 \le \rho}
+   \big[
+   \mathcal{L}(\boldsymbol{\theta}+\boldsymbol{\epsilon}) - \mathcal{L}(\boldsymbol{\theta})
+   \big].
+   $$
+
+3. **Trace-based proxies**
+   $$
+   \operatorname{tr}(H)
+   $$
+   as a measure of aggregate curvature.
+
+Each proxy answers a slightly different question. The top eigenvalue tracks the worst local direction. The trace tracks total curvature spread. Neighborhood maximization depends on the chosen radius $\rho$ and norm.
+
+Under a purely quadratic local approximation with stationary gradient, the neighborhood sharpness can be bounded by the top eigenvalue:
+
+$$
+S_\rho(\boldsymbol{\theta})
+\approx
+\max_{\|\boldsymbol{\epsilon}\|_2 \le \rho}
+\frac{1}{2}\boldsymbol{\epsilon}^\top H(\boldsymbol{\theta})\boldsymbol{\epsilon}
+=
+\frac{1}{2}\rho^2 \lambda_{\max}(H(\boldsymbol{\theta}))
+$$
+
+when the top eigendirection is feasible within the perturbation set and $H$ is locally stable. This is one reason $\lambda_{\max}(H)$ is such a widely used practical proxy.
+
+In practical deep-learning diagnostics, people often monitor one or more of:
+
+- $\lambda_{\max}(H)$
+- gradient norm $\|\nabla \mathcal{L}\|_2$
+- loss increase under random perturbations
+- the Hessian trace or diagonal approximations
+
+These can be useful, but they must always be read relative to scale, parameterization, and architecture.
+
+### 5.2 Flat Minima Intuition
+
+The classical intuition is simple and attractive: a flatter minimum should generalize better because small perturbations of the parameters leave the loss almost unchanged. That sounds like robustness, and robustness often sounds like generalization.
+
+More concretely, suppose two minima achieve similar training loss. If one has a wider neighborhood of low loss, then:
+
+- finite-precision errors hurt it less
+- stochastic optimization noise perturbs it less destructively
+- modest data shifts or checkpoint averaging may leave it usable
+
+This gives a plausible informal bridge from geometry to out-of-sample performance.
+
+The intuition also connects to Bayesian and information-theoretic viewpoints. Very roughly, broader low-loss regions occupy more volume in parameter space, so they can carry larger posterior mass under some priors or be encoded more compactly under some compression arguments.
+
+But this is only the start of the story, not the end.
+
+One good way to read the classical flat-minima idea is:
+
+> Wide low-loss neighborhoods are often a sign that the learned predictor is robust to some perturbations.
+
+That is a useful statement. The overreach begins when it is turned into:
+
+> A single raw weight-space flatness number fully explains generalization.
+
+The first statement is often insightful. The second is too strong.
+
+### 5.3 Reparameterization Caveats
+
+Dinh et al. made an important correction to the naive flat-minima story: many common sharpness measures are not invariant under simple reparameterizations.
+
+If we rescale parameters in a function-preserving way, we can often make a minimum look arbitrarily sharper or flatter in raw parameter coordinates without changing the model's predictions. That means a purely parameter-space notion of flatness is not automatically a meaningful explanation of generalization.
+
+This is the central caution:
+
+- **flatness can be useful**
+- **flatness can also be coordinate-artifacted**
+
+So a careful statement is:
+
+> Flatness may correlate with good solutions under a fixed parameterization and training setup, but raw parameter-space flatness is not by itself a universal, invariant explanation of generalization.
+
+This is why later work often shifts toward:
+
+- scale-normalized sharpness
+- function-space sensitivity
+- PAC-Bayes-style complexity measures
+- perturbations defined relative to parameter scale
+
+The right lesson is not "flatness is false." The right lesson is "flatness needs a geometry-aware definition."
+
+### 5.4 Batch Size, Noise, and Sharpness
+
+One of the most influential empirical observations in this area is that small-batch and large-batch training can behave differently even when both achieve low training loss. A common interpretation is:
+
+- smaller batches inject more gradient noise
+- that noise tends to avoid or escape sharp basins
+- the final solutions are often flatter, or at least less sharply curved in important directions
+
+This fits naturally with the stochastic optimization view from [Stochastic Optimization](../05-Stochastic-Optimization/notes.md). If the update is
+
+$$
+\boldsymbol{\theta}_{t+1}
+=
+\boldsymbol{\theta}_t - \eta \nabla \mathcal{L}(\boldsymbol{\theta}_t) - \eta \boldsymbol{\xi}_t,
+$$
+
+then the noise term $\boldsymbol{\xi}_t$ interacts with curvature. In highly curved basins, the same random fluctuation can produce larger loss increases than in broad flat valleys, making those sharp regions harder to remain inside.
+
+That said, this story is directionally useful but not the final theorem of large-scale training. In practice, batch-size effects are entangled with:
+
+- learning-rate scaling
+- schedule design
+- optimizer choice
+- normalization layers
+- training time budget
+
+So sharpness-sensitive interpretations should be combined with the dynamics, not used in isolation.
+
+### 5.5 What We Can Honestly Say About Generalization
+
+Here is the honest 2026-level summary.
+
+We can say with high confidence that:
+
+- landscape geometry influences robustness and optimization stability
+- some notions of flatness correlate with desirable behavior in fixed training pipelines
+- large-batch training often changes the geometry of the solutions reached
+- symmetry and reparameterization complicate naive parameter-space explanations
+
+We cannot say, at least not as a settled theorem, that:
+
+- "flat minima generalize better" is universally true without qualifications
+- one scalar sharpness metric explains generalization across architectures and scales
+- low-dimensional visualizations literally reveal the whole generalization story
+
+So the responsible stance is to use landscape measures as diagnostics and geometric clues, not as one-number explanations for why deep learning works.
+
+| Claim | Status |
+| --- | --- |
+| Sharpness affects optimization stability | strong practical support |
+| Small-batch noise changes the geometry of the solutions reached | strong practical support |
+| Raw parameter-space flatness is a universal explanation of generalization | not reliable |
+| Geometry matters for averaging and merging checkpoints | strong practical support |
+| One scalar curvature metric explains all training outcomes | not reliable |
+
+---
+
+## 6. Core Theory IV: Connectivity, Visualization, and Training Paths
+
+### 6.1 Linear Interpolation from Initialization to Solution
+
+Goodfellow et al. proposed a simple but influential diagnostic: linearly interpolate between two parameter vectors and plot the loss along the path.
+
+Given $\boldsymbol{\theta}_a$ and $\boldsymbol{\theta}_b$, define
+
+$$
+\boldsymbol{\theta}(t) = (1-t)\boldsymbol{\theta}_a + t\boldsymbol{\theta}_b,
+\quad t \in [0,1].
+$$
+
+Then study
+
+$$
+\phi(t) = \mathcal{L}(\boldsymbol{\theta}(t)).
+$$
+
+Two common experiments are:
+
+1. interpolate from initialization to a trained solution
+2. interpolate between two trained solutions
+
+The first experiment often reveals a surprisingly smooth descent, suggesting that at least along that specific path, there may be no catastrophic barrier. The second sometimes reveals a barrier if the two solutions differ by symmetry or live in disconnected-looking coordinates.
+
+Important caution: a single linear path is not the landscape. It is just one slice through a huge space. A visible barrier along that slice does not prove disconnection, and the absence of a barrier does not prove global simplicity.
+
+Still, interpolation plots remain valuable because they answer a concrete engineering question:
+
+> If I move between these two checkpoints in the simplest possible way, does loss explode?
+
+That is often enough to guide whether averaging, merging, or soup-style combinations are plausible.
+
+### 6.2 Meaningful Loss-Surface Visualization
+
+Directly plotting loss landscapes is hard because parameter spaces are enormous. A naive 2D slice can be misleading if one axis corresponds to a layer with huge norm and another to a layer with tiny norm.
+
+Li et al. improved this by using **filter normalization**, which rescales directions so that different layers contribute comparably to the slice. This makes visual comparisons across architectures more meaningful.
+
+The general setup is:
+
+$$
+\boldsymbol{\theta}(\alpha,\beta)
+=
+\boldsymbol{\theta}_0 + \alpha \mathbf{u} + \beta \mathbf{v},
+$$
+
+where $\mathbf{u}$ and $\mathbf{v}$ are chosen directions, often normalized in a layer-aware way.
+
+Visualization can then reveal qualitative differences such as:
+
+- plain deep nets showing sharper, more irregular surfaces
+- residual architectures showing smoother, more navigable local slices
+- batch-size or optimizer choices changing local basin width
+
+But even a very good 2D visualization remains a projection. It is a tool for comparison, not a direct photograph of the full objective.
+
+Three recurring visualization pitfalls are worth remembering:
+
+1. **Unnormalized directions** exaggerate some layers and suppress others.
+2. **Train-mode noise** from dropout or batch statistics can make slices look artificially rough.
+3. **Overinterpreting color maps** can create a false sense that a smooth-looking 2D plot means globally easy optimization.
+
+### 6.3 Mode Connectivity
+
+One of the most surprising empirical findings in deep learning is that two independently trained solutions can often be connected by a low-loss curve.
+
+Instead of a straight line, one searches for a curve $\gamma:[0,1]\to \mathbb{R}^p$ such that
+
+$$
+\gamma(0)=\boldsymbol{\theta}_a,
+\qquad
+\gamma(1)=\boldsymbol{\theta}_b,
+$$
+
+and
+
+$$
+\mathcal{L}(\gamma(t))
+$$
+
+remains small for all $t$.
+
+Garipov et al. and Draxler et al. showed that such curves often exist for modern deep networks. This phenomenon is called **mode connectivity**, although "mode" is a bit misleading because the endpoints are often not isolated probabilistic modes in the classical sense.
+
+Mode connectivity suggests several things:
+
+- the low-loss set may be much more connected than expected
+- independently trained checkpoints may not live in fundamentally separate basins
+- optimizer randomness may choose different coordinates for functionally similar regions
+
+It also motivates practical methods like fast ensembling, SWA-like averaging, and checkpoint soups.
+
+A common low-dimensional construction is a polygonal chain or a Bezier curve. For example, a quadratic Bezier path can be written as
+
+$$
+\gamma(t) = (1-t)^2\boldsymbol{\theta}_a + 2t(1-t)\mathbf{c} + t^2\boldsymbol{\theta}_b,
+$$
+
+where the control point $\mathbf{c}$ is optimized so that $\max_t \mathcal{L}(\gamma(t))$ stays small. This is not the only way to study connectivity, but it gives a concrete computational procedure.
+
+### 6.4 Training Trajectories and Barrier Crossing
+
+The optimizer path itself is a geometric object. Rather than only asking where it starts and ends, we can ask:
+
+- Does it stay near a low-dimensional subspace?
+- Does it move close to stability boundaries?
+- Does it skirt sharp barriers or cross them?
+- Do later iterates mostly average along a connected low-loss valley?
+
+Empirically, training trajectories in large networks often look surprisingly structured:
+
+- early phases rapidly reduce loss while curvature grows
+- later phases move within a lower-loss corridor with slower loss change
+- checkpoint averaging can improve generalization without additional optimization
+
+This supports the idea that training is not just descending into one isolated hole. Often it is entering and then navigating within an extended low-loss region.
+
+### 6.5 SWA, Model Soups, and Connectivity Exploitation
+
+If good checkpoints lie in related or connected low-loss regions, then averaging them can improve performance.
+
+**Stochastic Weight Averaging (SWA)** averages weights collected late in training:
+
+$$
+\bar{\boldsymbol{\theta}} = \frac{1}{K}\sum_{k=1}^K \boldsymbol{\theta}^{(k)}.
+$$
+
+The empirical intuition is that the average can land nearer the center of a broad low-loss region, reducing sensitivity and often improving test performance.
+
+**Model soups** extend a similar idea to separately fine-tuned checkpoints. If these checkpoints are functionally compatible enough, weight-space averaging can produce a model that is as good as or better than the ingredients.
+
+These methods are not magic. They work best when:
+
+- checkpoints are already in compatible low-loss regions
+- permutation/symmetry mismatches are not catastrophic
+- the loss along or near their connecting paths is not too high
+
+So they are practical evidence that landscape connectivity is not only a theoretical curiosity.
+
+---
+
+## 7. Advanced Topics
+
+### 7.1 Random-Matrix and Spectral Heuristics
+
+Hessian spectra in deep learning are often described using a **bulk plus outliers** picture:
+
+- a dense bulk of eigenvalues near zero
+- a small number of outlier directions with much larger curvature
+
+Random-matrix heuristics help interpret this structure. The bulk is often associated with overparameterization and many weakly constrained directions. The outliers may align with task-relevant or data-structured curvature directions.
+
+This picture is useful because it explains why:
+
+- most directions can be nearly flat
+- a small number of stiff directions govern stability
+- diagonal or low-rank curvature approximations sometimes work surprisingly well
+
+But it is still a heuristic lens, not a complete universal law.
+
+### 7.2 Edge of Stability and Catapult Dynamics
+
+A striking modern observation is that training often operates near an **edge of stability**, where the effective step size is close to the limit suggested by local curvature:
+
+$$
+\eta \lambda_{\max}(H) \approx 2.
+$$
+
+In simple quadratic models, crossing that boundary causes divergence. In deep learning, the story is subtler: training can hover near this edge, with curvature and dynamics co-adapting over time.
+
+Related large-learning-rate analyses discuss a **catapult phase**, where initially unstable-seeming steps can still lead to a regime of lower curvature and successful descent.
+
+These phenomena matter because they explain why:
+
+- aggressive learning rates sometimes help rather than hurt
+- curvature monitoring can be a valuable debugging tool
+- schedule design cannot be separated cleanly from landscape evolution
+
+This is one of the clearest modern examples of optimization dynamics and geometry shaping each other in real time.
+
+Operationally, this matters because curvature is not fixed during training. The optimizer changes the parameters, the parameters change the curvature, and the changed curvature alters which step sizes are safe. Landscape analysis therefore becomes dynamic rather than static.
+
+### 7.3 Landscape-Aware Objectives
+
+Some optimization methods explicitly try to bias training toward flatter or more robust regions.
+
+A local-sharpness-aware objective can be written schematically as
+
+$$
+\min_{\boldsymbol{\theta}}
+\max_{\|\boldsymbol{\epsilon}\|\le \rho}
+\mathcal{L}(\boldsymbol{\theta}+\boldsymbol{\epsilon}).
+$$
+
+This is the intuition behind methods like Sharpness-Aware Minimization (SAM). Instead of only minimizing the loss at one point, the method seeks parameters whose entire neighborhood has low loss.
+
+There are also entropy-inspired objectives that effectively reward wide low-loss basins rather than only pointwise minima.
+
+These belong more fully to optimizer design and regularization, but the geometric motivation is landscape-centric, so this section gives the conceptual bridge.
+
+### 7.4 Function-Space Flatness and PAC-Bayes-Flavored Views
+
+To avoid the scale-symmetry problems of raw parameter-space flatness, several modern approaches define complexity in a more invariant or prediction-relevant way:
+
+- perturb outputs rather than raw weights
+- normalize perturbations by parameter scale
+- use posterior neighborhoods over functions
+- derive bounds from PAC-Bayes-style complexity terms
+
+The common idea is that robustness of the **implemented predictor** is often more meaningful than robustness of one arbitrary parameterization.
+
+This is mathematically harder, but conceptually cleaner.
+
+In practice, this motivates a hierarchy of trust:
+
+- lowest trust: raw unnormalized parameter-space flatness
+- medium trust: scale-aware or normalized sharpness measures
+- higher trust: function-space sensitivity, perturbation robustness, or prediction-preserving complexity measures
+
+### 7.5 Open Problems for Frontier Models
+
+Frontier-model landscape theory is still incomplete. Important open questions include:
+
+- how sparsity and pruning change connectivity and curvature
+- how quantization reshapes low-loss neighborhoods
+- how RLHF or preference optimization alters local geometry
+- how multimodal models compare with text-only models
+- whether function-space connectivity remains as strong in very large post-training pipelines
+
+In 2026, landscape ideas are useful and influential, but they are not a finished explanatory theory of foundation-model training.
+
+---
+
+## 8. Applications in Machine Learning
+
+### 8.1 Why Residual Connections Help
+
+Residual networks often train more easily than equally deep plain networks. One influential explanation is geometric: skip connections smooth optimization by making the effective mapping closer to an identity perturbation.
+
+If a residual block is
+
+$$
+\mathbf{h}_{\ell+1} = \mathbf{h}_\ell + F_\ell(\mathbf{h}_\ell),
+$$
+
+then optimization can modify behavior incrementally rather than forcing each layer stack to learn a complete transformation from scratch.
+
+This tends to:
+
+- reduce pathological curvature
+- improve gradient flow
+- create more navigable local landscape slices
+
+The result is not that residual networks become convex. It is that the geometry becomes easier for first-order training to navigate.
+
+This is a recurring pattern in AI system design: the most successful architectures often do not remove nonconvexity, but they reshape it into a form that common optimizers can handle more reliably.
+
+### 8.2 Diagnosing Training Instability
+
+Landscape tools can help debug failed or unstable training runs.
+
+Useful diagnostics include:
+
+- top Hessian eigenvalue estimates
+- gradient norm and update norm
+- interpolation checks between nearby checkpoints
+- perturbation-based sharpness estimates
+- loss under small random parameter noise
+
+For example, if loss spikes occur while $\lambda_{\max}(H)$ is rising and the effective learning rate is unchanged, the problem may be local curvature instability rather than data noise or bad initialization.
+
+Similarly, if two checkpoints with similar validation accuracy cannot be averaged without damage, they may occupy parameter regions separated by symmetry or incompatibility.
+
+A practical landscape-debugging loop looks like this:
+
+1. estimate gradient norm and update norm
+2. estimate or approximate top curvature
+3. perturb the checkpoint slightly and measure loss change
+4. interpolate to nearby checkpoints
+5. decide whether the problem is instability, incompatibility, or undertraining
+
+This loop is much more informative than staring at the scalar training loss alone.
+
+### 8.3 Large-Batch Training and Generalization Gaps
+
+Large-batch training is attractive because it improves hardware efficiency and distributed throughput. But it can also change the optimization geometry that is sampled.
+
+The common landscape-based interpretation is:
+
+- large batches reduce gradient noise
+- reduced noise makes it easier to settle into sharper regions
+- those regions may be less robust under perturbation
+
+This is not the full story, but it remains a useful working model when comparing:
+
+- small-batch SGD
+- large-batch SGD
+- large-batch adaptive training
+- carefully scheduled warmup and decay strategies
+
+This section does not replace the full scaling discussion in [Stochastic Optimization](../05-Stochastic-Optimization/notes.md); it supplies the geometric vocabulary behind it.
+
+### 8.4 Fine-Tuning, LoRA, and Low-Dimensional Updates
+
+Fine-tuning results suggest that useful downstream adaptation often lives in surprisingly low-dimensional or structured subspaces.
+
+LoRA-style updates write parameter changes as low-rank perturbations:
+
+$$
+\Delta W = BA,
+$$
+
+with rank much smaller than the full matrix dimensions.
+
+From a landscape viewpoint, this suggests that:
+
+- downstream task adaptation may align with a small subset of meaningful directions
+- many parameter directions are redundant or weakly relevant
+- the local low-loss region can be navigated effectively with restricted update geometry
+
+This does not mean the whole loss landscape is low-dimensional. It means the **useful** movement for certain adaptation tasks may occupy only a small structured part of it.
+
+That distinction is important. The ambient loss may still have huge dimensional complexity, but downstream adaptation may only need a narrow corridor inside that larger space.
+
+### 8.5 Ensembles, Averaging, and Checkpoint Merging
+
+Landscape connectivity helps explain why several practical techniques work:
+
+- checkpoint averaging during one run
+- SWA across late iterates
+- model soups across fine-tuned runs
+- sometimes even direct merging of nearby task-specialized models
+
+If solutions lie in a connected or gently curved low-loss region, then averaging can move toward a more central, robust point. If solutions are separated by incompatible symmetry choices or different functional modes, averaging may fail.
+
+So successful checkpoint merging is not just an implementation trick. It is a geometric claim about the local shape and connectivity of the solution set.
+
+It also explains why some merges fail dramatically: if the endpoints represent incompatible symmetries, task heads, normalization statistics, or function-space behaviors, the average can land outside the useful low-loss corridor.
+
+---
+
+## 9. Common Mistakes
+
+| # | Mistake | Why It Is Wrong | Fix |
+| --- | --- | --- | --- |
+| 1 | Treating every nonconvex problem as "many bad local minima" | In high-dimensional deep learning, saddle points and degenerate flat regions are often more important than poor isolated minima | Analyze curvature structure, not only the existence of local minima |
+| 2 | Reading a 2D loss plot as the real full landscape | Any 2D slice is only a projection through a huge parameter space | Use visualizations comparatively and with normalization, not literally |
+| 3 | Equating low gradient norm with a good solution | Saddles and plateaus can also have tiny gradients | Pair gradient norms with curvature diagnostics |
+| 4 | Treating Hessian eigenvalues only as optimizer information | They are also geometric summaries of local structure | Use Hessian spectra to reason about minima, saddles, and stability |
+| 5 | Saying "flat minima generalize better" with no caveats | Raw parameter-space flatness is not invariant under common reparameterizations | Use normalized or function-aware notions of flatness and state assumptions clearly |
+| 6 | Assuming two distant checkpoints represent different functions | Symmetry and redundant parameterization can make far-apart weights functionally similar | Compare function-space behavior, not only Euclidean distance |
+| 7 | Assuming a barrier along linear interpolation proves disconnection | A different nonlinear path may connect the solutions with low loss | Distinguish linear interpolation failure from genuine disconnectedness |
+| 8 | Assuming mode connectivity means every average of checkpoints will work | Connectivity is geometry-dependent and can be broken by symmetry mismatch or task mismatch | Test interpolation and compatibility before averaging |
+| 9 | Treating sharpness as one scalar universal truth | Different sharpness metrics answer different questions and depend on scale and norm | State the metric, radius, and invariances explicitly |
+| 10 | Using landscape stories as substitutes for dynamics | Geometry and optimizer dynamics interact; one without the other is incomplete | Combine landscape reasoning with SGD, schedules, and batch-size analysis |
+| 11 | Believing overparameterization means the loss is easy everywhere | Overparameterization can help, but unstable directions, plateaus, and poor transients still exist | Analyze both solution-set geometry and training trajectories |
+| 12 | Confusing parameter-space smoothness with output robustness | Small changes in weights can matter a lot or very little depending on the function geometry | Check output sensitivity or task-level robustness directly |
+
+---
+
+## 10. Exercises
+
+These exercises are designed to move from local critical-point mechanics to modern AI landscape interpretation.
+
+### Exercise 1 [$\star$] Critical-Point Classification
+
+Consider the scalar and low-dimensional objectives:
+
+1. $f_1(x) = x^4$
+2. $f_2(x,y) = x^2 - y^2$
+3. $f_3(x,y) = x^2 + y^4$
+
+For each:
+
+- find the critical points
+- compute the Hessian where possible
+- classify the point as minimum, saddle, or degenerate case
+- explain where second-order information is insufficient
+
+### Exercise 2 [$\star$] Hessian Eigenvalues and Local Geometry
+
+Let
+
+$$
+H =
+\begin{bmatrix}
+3 & 1 \\
+1 & -2
+\end{bmatrix}.
+$$
+
+1. Compute the eigenvalues and eigenvectors.
+2. Determine whether the associated critical point is a strict saddle.
+3. Sketch the local quadratic form
+   $$
+   q(\mathbf{d}) = \frac{1}{2}\mathbf{d}^\top H \mathbf{d}.
+   $$
+4. Identify the most unstable direction.
+
+### Exercise 3 [$\star\star$] Deep Linear Landscape
+
+Consider the deep linear model
+
+$$
+f(x) = W_2 W_1 x
+$$
+
+with squared loss on a small regression problem.
+
+1. Show that the objective is nonconvex in $(W_1,W_2)$.
+2. Explain why the same end-to-end matrix can be represented by multiple factorizations.
+3. Numerically train the model from several initializations.
+4. Compare final training losses and discuss whether you observe many bad local minima or mostly equivalent solutions.
+
+### Exercise 4 [$\star\star$] Sharpness Under Reparameterization
+
+Take a simple positively homogeneous model and construct a function-preserving rescaling of parameters.
+
+1. Show that the outputs remain unchanged.
+2. Compute or estimate a local sharpness proxy before and after rescaling.
+3. Explain why the change in sharpness does not imply a change in the learned function.
+4. State what this teaches about naive flatness claims.
+
+### Exercise 5 [$\star\star$] Interpolation Path Analysis
+
+Train a small neural network twice from different random seeds.
+
+1. Compute the linear interpolation
+   $$
+   \boldsymbol{\theta}(t) = (1-t)\boldsymbol{\theta}_a + t\boldsymbol{\theta}_b.
+   $$
+2. Plot training loss and validation loss along the path.
+3. Measure the barrier height.
+4. Interpret whether the two solutions appear linearly connected.
+5. Explain why a barrier here does or does not prove disconnection of the low-loss set.
+
+### Exercise 6 [$\star\star\star$] Mode Connectivity Construction
+
+Using the same pair of trained networks from Exercise 5:
+
+1. Fit a simple polygonal or quadratic Bezier connecting curve between the endpoints.
+2. Optimize the intermediate control point(s) to reduce the maximum path loss.
+3. Compare the best nonlinear path to the straight-line path.
+4. Explain what your result suggests about the global structure of the low-loss region.
+
+### Exercise 7 [$\star\star\star$] Curvature During Training
+
+During training of a small neural network:
+
+1. Estimate the top Hessian eigenvalue every few epochs.
+2. Record training loss, validation loss, and gradient norm.
+3. Check whether the quantity
+   $$
+   \eta \lambda_{\max}(H)
+   $$
+   approaches the stability boundary.
+4. Discuss whether the run seems to spend time near an edge-of-stability regime.
+
+### Exercise 8 [$\star\star\star$] Landscape-Aware Diagnosis of an ML System
+
+Choose one of the following and analyze it with landscape concepts:
+
+- a large-batch training failure
+- a successful SWA or soup average
+- a LoRA fine-tuning run
+- a residual-vs-plain architecture comparison
+
+Your answer should include:
+
+- the geometric hypothesis
+- the measurements you would collect
+- the expected signatures in curvature, sharpness, or connectivity
+- one concrete intervention motivated by that geometry
+
+---
+
+## 11. Why This Matters for AI (2026 Perspective)
+
+| Aspect | Why It Matters |
+| --- | --- |
+| Saddle structure | Helps explain why stochastic training can keep moving even when gradients get small |
+| Hessian outliers | High-curvature directions often govern stability and learning-rate limits in large models |
+| Near-zero eigenvalue bulk | Supports the picture of overparameterized, highly degenerate low-loss regions |
+| Sharpness-aware objectives | Motivates practical methods that seek neighborhoods of low loss rather than single-point minima |
+| Large-batch geometry | Helps interpret when scale-up hurts robustness or validation performance |
+| Mode connectivity | Explains why checkpoint averaging, SWA, and soups can work surprisingly well |
+| Residual architectures | Connects architectural design to trainability via smoother, more navigable landscapes |
+| LoRA and low-rank tuning | Suggests useful task adaptation often lies in structured low-dimensional directions |
+| Edge-of-stability behavior | Gives a modern lens on why aggressive learning rates can help before destabilizing |
+| Function-vs-parameter geometry | Essential for thinking clearly about fine-tuning, merging, and robustness in frontier systems |
+| Quantized and compressed models | Low-loss neighborhood width affects how much perturbation a model can tolerate after compression |
+| Foundation-model debugging | Landscape diagnostics increasingly matter because each failed run is expensive in compute and time |
+
+---
+
+## 12. Conceptual Bridge
+
+This section closes the first half of the optimization chapter. [Convex Optimization](../01-Convex-Optimization/notes.md) gave us the clean world where geometry globally guarantees success. [Gradient Descent](../02-Gradient-Descent/notes.md) and [Second-Order Methods](../03-Second-Order-Methods/notes.md) taught us how updates react to curvature. [Stochastic Optimization](../05-Stochastic-Optimization/notes.md) added noise, batch size, and distributed scale. Optimization landscape now explains the terrain those methods are traversing when the objective is no longer convex and the model is massively overparameterized.
+
+The next natural step is not to abandon geometry, but to operationalize it. [Adaptive Learning Rate](../07-Adaptive-Learning-Rate/notes.md) asks how optimizers reshape updates direction-by-direction in response to local signal scale. [Regularization Methods](../08-Regularization-Methods/notes.md) asks how we deliberately bias training toward robust or simpler solutions. [Hyperparameter Optimization](../09-Hyperparameter-Optimization/notes.md) and [Learning Rate Schedules](../10-Learning-Rate-Schedules/notes.md) ask how to steer these dynamics at system scale.
+
+The backward connection is equally important. If you ever feel landscape language becoming too hand-wavy, return to the earlier chapters:
+
+- return to convexity for the clean baseline
+- return to Hessians for the exact local curvature meaning
+- return to SGD theory for noise and batch-size effects
+
+That loop is how you keep landscape intuition mathematically disciplined.
+
+```text
+OPTIMIZATION CHAPTER POSITION
+==============================================================
+
+Convex Optimization
+        |
+        v
+Gradient Descent
+        |
+        v
+Second-Order Methods
+        |
+        v
+Constrained Optimization
+        |
+        v
+Stochastic Optimization
+        |
+        v
+Optimization Landscape
+        |
+        +-----------------> Adaptive Learning Rate
+        +-----------------> Regularization Methods
+        +-----------------> Hyperparameter Optimization
+        +-----------------> Learning Rate Schedules
+
+Landscape is the geometry bridge between optimization theory
+and practical large-scale training behavior.
+==============================================================
+```
+
+## References
+
+### Local Chapter References
+
+1. [Convex Optimization](../01-Convex-Optimization/notes.md)
+2. [Gradient Descent](../02-Gradient-Descent/notes.md)
+3. [Second-Order Methods](../03-Second-Order-Methods/notes.md)
+4. [Stochastic Optimization](../05-Stochastic-Optimization/notes.md)
+5. [Optimization README](../README.md)
+
+### Primary External Sources
+
+1. Hochreiter, S., and Schmidhuber, J. _Flat Minima_. Neural Computation, 1997.
+2. Dauphin, Y. N., Pascanu, R., Gulcehre, C., Cho, K., Ganguli, S., and Bengio, Y. _Identifying and attacking the saddle point problem in high-dimensional non-convex optimization_. NeurIPS 2014. [arXiv](https://arxiv.org/abs/1406.2572)
+3. Goodfellow, I., Vinyals, O., and Saxe, A. _Qualitatively characterizing neural network optimization problems_. ICLR 2015 workshop version. [arXiv](https://arxiv.org/abs/1412.6544)
+4. Keskar, N. S., Mudigere, D., Nocedal, J., Smelyanskiy, M., and Tang, P. T. P. _On Large-Batch Training for Deep Learning: Generalization Gap and Sharp Minima_. ICLR 2017. [arXiv](https://arxiv.org/abs/1609.04836)
+5. Dinh, L., Pascanu, R., Bengio, S., and Bengio, Y. _Sharp Minima Can Generalize For Deep Nets_. ICML 2017. [PMLR](https://proceedings.mlr.press/v70/dinh17b.html)
+6. Sagun, L., Evci, U., Guney, V. U., Dauphin, Y., and Bottou, L. _Empirical Analysis of the Hessian of Over-Parametrized Neural Networks_. 2017. [arXiv](https://arxiv.org/abs/1706.04454)
+7. Li, H., Xu, Z., Taylor, G., Studer, C., and Goldstein, T. _Visualizing the Loss Landscape of Neural Nets_. NeurIPS 2018. [arXiv](https://arxiv.org/abs/1712.09913)
+8. Garipov, T., Izmailov, P., Podoprikhin, D., Vetrov, D., and Wilson, A. G. _Loss Surfaces, Mode Connectivity, and Fast Ensembling of DNNs_. NeurIPS 2018. [arXiv](https://arxiv.org/abs/1802.10026)
+9. Draxler, F., Veschgini, K., Salmhofer, M., and Hamprecht, F. A. _Essentially No Barriers in Neural Network Energy Landscape_. ICML 2018. [arXiv](https://arxiv.org/abs/1803.00885)
+10. Cohen, J., Kaur, S., Li, Y., Kolter, J. Z., and Talwalkar, A. _Gradient Descent on Neural Networks Typically Occurs at the Edge of Stability_. ICLR 2022. [arXiv](https://arxiv.org/abs/2103.00065)
+11. Lewkowycz, A., Bahri, Y., Dyer, E., Sohl-Dickstein, J., and Gur-Ari, G. _The large learning rate phase of deep learning: the catapult mechanism_. 2020. [arXiv](https://arxiv.org/abs/2003.02218)
+
+### Supplemental Perspective Sources
+
+1. Pittorino, F., Ferraro, A., Perugini, G., Feinauer, C., Baldassi, C., and Zecchina, R. _Deep Networks on Toroids: Removing Symmetries Reveals the Structure of Flat Regions in the Landscape Geometry_. ICML 2022. [PMLR](https://proceedings.mlr.press/v162/pittorino22a.html)
+2. Ghorbani, B., Krishnan, S., and Xiao, Y. _An Investigation into Neural Net Optimization via Hessian Eigenvalue Density_. ICML 2019. [PMLR](https://proceedings.mlr.press/v97/ghorbani19b.html)

--- a/08-Optimization/06-Optimization-Landscape/theory.ipynb
+++ b/08-Optimization/06-Optimization-Landscape/theory.ipynb
@@ -1,0 +1,803 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Optimization Landscape\n",
+        "\n",
+        "This notebook is the interactive companion to `notes.md`. It uses small but expressive toy objectives to build the main ideas behind optimization landscapes: saddles, degeneracy, symmetry, sharpness, connectivity, and stability.\n",
+        "\n",
+        "**Coverage:** critical points, Hessian spectra, sharpness proxies, parameter-space symmetry, interpolation barriers, mode connectivity, overparameterized minima, and edge-of-stability intuition.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import matplotlib as mpl\n",
+        "\n",
+        "try:\n",
+        "    import seaborn as sns\n",
+        "    sns.set_theme(style=\"whitegrid\", palette=\"colorblind\")\n",
+        "    HAS_SNS = True\n",
+        "except ImportError:\n",
+        "    plt.style.use(\"seaborn-v0_8-whitegrid\")\n",
+        "    HAS_SNS = False\n",
+        "\n",
+        "mpl.rcParams.update({\n",
+        "    \"figure.figsize\": (10, 6),\n",
+        "    \"figure.dpi\": 120,\n",
+        "    \"font.size\": 13,\n",
+        "    \"axes.titlesize\": 15,\n",
+        "    \"axes.labelsize\": 13,\n",
+        "    \"xtick.labelsize\": 11,\n",
+        "    \"ytick.labelsize\": 11,\n",
+        "    \"legend.fontsize\": 11,\n",
+        "    \"legend.framealpha\": 0.85,\n",
+        "    \"lines.linewidth\": 2.0,\n",
+        "    \"axes.spines.top\": False,\n",
+        "    \"axes.spines.right\": False,\n",
+        "    \"savefig.bbox\": \"tight\",\n",
+        "    \"savefig.dpi\": 150,\n",
+        "})\n",
+        "np.random.seed(42)\n",
+        "print(\"Plot setup complete.\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "COLORS = {\n",
+        "    \"primary\": \"#0077BB\",\n",
+        "    \"secondary\": \"#EE7733\",\n",
+        "    \"tertiary\": \"#009988\",\n",
+        "    \"error\": \"#CC3311\",\n",
+        "    \"neutral\": \"#555555\",\n",
+        "    \"highlight\": \"#EE3377\",\n",
+        "}\n",
+        "\n",
+        "def header(title):\n",
+        "    print(\"\\n\" + \"=\" * 78)\n",
+        "    print(title)\n",
+        "    print(\"=\" * 78)\n",
+        "\n",
+        "def check_close(name, value, target, tol=1e-8):\n",
+        "    ok = np.allclose(value, target, atol=tol, rtol=tol)\n",
+        "    print(f\"{'PASS' if ok else 'FAIL'} - {name}\")\n",
+        "    if not ok:\n",
+        "        print(\"  value :\", value)\n",
+        "        print(\"  target:\", target)\n",
+        "    return ok\n",
+        "\n",
+        "def check_true(name, condition):\n",
+        "    print(f\"{'PASS' if condition else 'FAIL'} - {name}\")\n",
+        "    return condition\n",
+        "\n",
+        "def numerical_hessian(f, theta, eps=1e-5):\n",
+        "    theta = np.array(theta, dtype=float)\n",
+        "    n = theta.size\n",
+        "    H = np.zeros((n, n))\n",
+        "    for i in range(n):\n",
+        "        for j in range(n):\n",
+        "            e_i = np.zeros(n)\n",
+        "            e_j = np.zeros(n)\n",
+        "            e_i[i] = eps\n",
+        "            e_j[j] = eps\n",
+        "            H[i, j] = (\n",
+        "                f(theta + e_i + e_j)\n",
+        "                - f(theta + e_i - e_j)\n",
+        "                - f(theta - e_i + e_j)\n",
+        "                + f(theta - e_i - e_j)\n",
+        "            ) / (4 * eps**2)\n",
+        "    return H\n",
+        "\n",
+        "def loss_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return 0.5 * (u * v - 1.0) ** 2\n",
+        "\n",
+        "def grad_uv(theta):\n",
+        "    u, v = theta\n",
+        "    err = u * v - 1.0\n",
+        "    return err * np.array([v, u], dtype=float)\n",
+        "\n",
+        "def hess_uv(theta):\n",
+        "    u, v = theta\n",
+        "    return np.array([\n",
+        "        [v**2, 2 * u * v - 1.0],\n",
+        "        [2 * u * v - 1.0, u**2],\n",
+        "    ], dtype=float)\n",
+        "\n",
+        "def scalar_model_outputs(theta, xs):\n",
+        "    u, v = theta\n",
+        "    return (u * v) * xs\n",
+        "\n",
+        "def line_path(a, b, ts):\n",
+        "    return np.array([(1 - t) * np.array(a) + t * np.array(b) for t in ts])\n",
+        "\n",
+        "def bezier_path(a, c, b, ts):\n",
+        "    a = np.array(a, dtype=float)\n",
+        "    b = np.array(b, dtype=float)\n",
+        "    c = np.array(c, dtype=float)\n",
+        "    return np.array([(1 - t) ** 2 * a + 2 * t * (1 - t) * c + t ** 2 * b for t in ts])\n",
+        "\n",
+        "def path_barrier(path, loss_fn):\n",
+        "    vals = np.array([loss_fn(p) for p in path])\n",
+        "    return vals.max() - max(vals[0], vals[-1]), vals\n",
+        "\n",
+        "def loss_abc(theta):\n",
+        "    a, b, c = theta\n",
+        "    return 0.5 * (a * b * c - 1.0) ** 2\n",
+        "\n",
+        "def grad_abc(theta):\n",
+        "    a, b, c = theta\n",
+        "    err = a * b * c - 1.0\n",
+        "    return err * np.array([b * c, a * c, a * b], dtype=float)\n",
+        "\n",
+        "print(\"Helpers ready.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Local Geometry with a Symmetric Toy Loss\n",
+        "\n",
+        "We will use the scalar factorization objective\n",
+        "\n",
+        "$$\n",
+        "\\mathcal{L}(u,v) = \\frac{1}{2}(uv - 1)^2.\n",
+        "$$\n",
+        "\n",
+        "It is tiny, but it already contains several key features of deep-learning landscapes:\n",
+        "\n",
+        "- nonconvex parameterization\n",
+        "- a strict saddle at the origin\n",
+        "- a full manifold of global minima given by $uv = 1$\n",
+        "- scaling symmetry $(u,v) \\mapsto (cu, v/c)$\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Critical points of the scalar factorization loss\")\n",
+        "saddle = np.array([0.0, 0.0])\n",
+        "minimum_a = np.array([1.0, 1.0])\n",
+        "minimum_b = np.array([2.0, 0.5])\n",
+        "\n",
+        "H_saddle = hess_uv(saddle)\n",
+        "H_min_a = hess_uv(minimum_a)\n",
+        "H_min_b = hess_uv(minimum_b)\n",
+        "\n",
+        "print(\"Hessian at saddle:\\n\", H_saddle)\n",
+        "print(\"Eigenvalues at saddle:\", np.linalg.eigvalsh(H_saddle))\n",
+        "print(\"Hessian at (1,1):\\n\", H_min_a)\n",
+        "print(\"Eigenvalues at (1,1):\", np.linalg.eigvalsh(H_min_a))\n",
+        "print(\"Hessian at (2,0.5):\\n\", H_min_b)\n",
+        "print(\"Eigenvalues at (2,0.5):\", np.linalg.eigvalsh(H_min_b))\n",
+        "\n",
+        "check_true(\"Origin is a strict saddle\", np.min(np.linalg.eigvalsh(H_saddle)) < 0 < np.max(np.linalg.eigvalsh(H_saddle)))\n",
+        "check_close(\"Loss at both minima is zero\", np.array([loss_uv(minimum_a), loss_uv(minimum_b)]), np.zeros(2))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Contour plot of the scalar factorization landscape\")\n",
+        "u = np.linspace(-2.5, 2.5, 400)\n",
+        "v = np.linspace(-2.5, 2.5, 400)\n",
+        "U, V = np.meshgrid(u, v)\n",
+        "Z = 0.5 * (U * V - 1.0) ** 2\n",
+        "\n",
+        "fig, ax = plt.subplots()\n",
+        "cs = ax.contour(U, V, Z, levels=[0.0, 0.02, 0.1, 0.25, 0.5, 1.0, 2.0], colors=COLORS[\"primary\"])\n",
+        "ax.clabel(cs, inline=True, fontsize=9)\n",
+        "ax.axhline(0, color=\"black\", linewidth=0.8)\n",
+        "ax.axvline(0, color=\"black\", linewidth=0.8)\n",
+        "ax.scatter([0, 1, 2], [0, 1, 0.5], c=[COLORS[\"error\"], COLORS[\"tertiary\"], COLORS[\"secondary\"]], s=60)\n",
+        "ax.set_title(r\"Contours of $\\mathcal{L}(u,v)=\\frac{1}{2}(uv-1)^2$\")\n",
+        "ax.set_xlabel(\"u\")\n",
+        "ax.set_ylabel(\"v\")\n",
+        "plt.show()\n",
+        "check_true(\"Global minima lie on the hyperbola uv=1\", loss_uv(np.array([1.25, 0.8])) < 1e-12)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**What to notice:** the bottom of the landscape is not an isolated point. It is an entire curve. This is the simplest possible illustration of a nonconvex landscape with many equivalent minima.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Sharpness varies along the same zero-loss manifold\")\n",
+        "us = np.logspace(-1, 1, 200)\n",
+        "nonzero_eigs = []\n",
+        "for u_val in us:\n",
+        "    H = hess_uv(np.array([u_val, 1.0 / u_val]))\n",
+        "    eigs = np.linalg.eigvalsh(H)\n",
+        "    nonzero_eigs.append(eigs[-1])\n",
+        "nonzero_eigs = np.array(nonzero_eigs)\n",
+        "\n",
+        "min_idx = np.argmin(nonzero_eigs)\n",
+        "print(\"Minimum nonzero eigenvalue occurs near u =\", us[min_idx])\n",
+        "print(\"Smallest nonzero eigenvalue =\", nonzero_eigs[min_idx])\n",
+        "print(\"Eigenvalue at (1,1) =\", hess_uv(np.array([1.0, 1.0])).trace())\n",
+        "check_true(\"Balanced factorization is the least sharp on this manifold\", abs(np.log10(us[min_idx])) < 0.1)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Curvature along the manifold uv=1\")\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(us, nonzero_eigs, color=COLORS[\"highlight\"])\n",
+        "ax.set_xscale(\"log\")\n",
+        "ax.set_title(\"Nonzero Hessian eigenvalue along equivalent minima\")\n",
+        "ax.set_xlabel(\"u on the manifold v = 1/u\")\n",
+        "ax.set_ylabel(\"Largest eigenvalue\")\n",
+        "plt.show()\n",
+        "check_true(\"Strongly unbalanced factorizations look sharper\", nonzero_eigs[0] > nonzero_eigs[min_idx] and nonzero_eigs[-1] > nonzero_eigs[min_idx])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Parameter Space vs Function Space\n",
+        "\n",
+        "The points $(0.5, 2)$ and $(2, 0.5)$ are far apart in parameter space, but they define the same scalar function $x \\mapsto uvx = x$.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Parameter distance can disagree with function distance\")\n",
+        "theta_a = np.array([0.5, 2.0])\n",
+        "theta_b = np.array([2.0, 0.5])\n",
+        "xs = np.linspace(-3, 3, 200)\n",
+        "\n",
+        "param_distance = np.linalg.norm(theta_a - theta_b)\n",
+        "func_distance = np.mean((scalar_model_outputs(theta_a, xs) - scalar_model_outputs(theta_b, xs)) ** 2)\n",
+        "\n",
+        "print(\"Parameter distance =\", param_distance)\n",
+        "print(\"Function-space MSE =\", func_distance)\n",
+        "check_true(\"The parameter vectors are far apart\", param_distance > 2.0)\n",
+        "check_close(\"The implemented functions are identical\", func_distance, 0.0)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Linear interpolation can show a barrier even between equivalent functions\")\n",
+        "ts = np.linspace(0, 1, 401)\n",
+        "linear_path = line_path(theta_a, theta_b, ts)\n",
+        "linear_barrier, linear_vals = path_barrier(linear_path, loss_uv)\n",
+        "print(\"Barrier along the straight line =\", linear_barrier)\n",
+        "check_true(\"The linear path rises above zero loss\", linear_barrier > 0.05)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"A nonlinear path can connect the same endpoints at zero loss\")\n",
+        "us_path = np.exp((1 - ts) * np.log(theta_a[0]) + ts * np.log(theta_b[0]))\n",
+        "nonlinear_path = np.stack([us_path, 1.0 / us_path], axis=1)\n",
+        "nonlinear_barrier, nonlinear_vals = path_barrier(nonlinear_path, loss_uv)\n",
+        "print(\"Barrier along the hyperbola path =\", nonlinear_barrier)\n",
+        "check_close(\"Nonlinear path stays on the zero-loss manifold\", nonlinear_barrier, 0.0, tol=1e-12)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Straight line versus nonlinear low-loss path\")\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(ts, linear_vals, label=\"Linear interpolation\", color=COLORS[\"secondary\"])\n",
+        "ax.plot(ts, nonlinear_vals, label=\"Nonlinear manifold path\", color=COLORS[\"tertiary\"])\n",
+        "ax.set_title(\"Loss along two paths between equivalent solutions\")\n",
+        "ax.set_xlabel(\"t\")\n",
+        "ax.set_ylabel(\"Loss\")\n",
+        "ax.legend()\n",
+        "plt.show()\n",
+        "check_true(\"Mode-connectivity intuition beats straight-line intuition here\", linear_vals.max() > nonlinear_vals.max() + 0.05)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Overparameterization Creates Flat Directions\n",
+        "\n",
+        "We now move from two parameters to three:\n",
+        "\n",
+        "$$\n",
+        "\\mathcal{L}(a,b,c) = \\frac{1}{2}(abc - 1)^2.\n",
+        "$$\n",
+        "\n",
+        "The global minimum condition $abc = 1$ leaves two free degrees of freedom, so we expect even more degeneracy.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Three-factor model: Hessian rank at a minimum\")\n",
+        "theta_star = np.array([1.0, 1.0, 1.0])\n",
+        "H_num = numerical_hessian(loss_abc, theta_star)\n",
+        "eigs = np.linalg.eigvalsh(H_num)\n",
+        "print(\"Numerical Hessian at (1,1,1):\\n\", H_num)\n",
+        "print(\"Eigenvalues:\", eigs)\n",
+        "check_true(\"Two directions are nearly flat\", np.sum(np.abs(eigs) < 1e-4) >= 2)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Gradient descent lands at different points on the same manifold\")\n",
+        "starts = [\n",
+        "    np.array([1.6, 0.8, 0.7]),\n",
+        "    np.array([0.4, 2.5, 1.2]),\n",
+        "    np.array([2.0, 0.5, 1.5]),\n",
+        "]\n",
+        "finals = []\n",
+        "for start in starts:\n",
+        "    theta = start.copy().astype(float)\n",
+        "    for _ in range(4000):\n",
+        "        theta -= 0.03 * grad_abc(theta)\n",
+        "    finals.append(theta.copy())\n",
+        "\n",
+        "finals = np.array(finals)\n",
+        "products = np.prod(finals, axis=1)\n",
+        "print(\"Final points:\\n\", finals)\n",
+        "print(\"Products abc:\\n\", products)\n",
+        "check_close(\"All runs end on or near abc=1\", products, np.ones_like(products), tol=1e-5)\n",
+        "check_true(\"Runs end at different parameter vectors\", np.linalg.norm(finals[0] - finals[1]) > 0.1)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**What to notice:** overparameterization does not force one unique optimum. It often creates a family of solutions, and optimization chooses one representative from that family.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Sharpness Proxies and Reparameterization Caveats\n",
+        "\n",
+        "A common practical sharpness proxy is $\\frac{1}{2}\\rho^2 \\lambda_{\\max}(H)$ for some perturbation radius $\\rho$.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Sharpness proxy on balanced vs unbalanced but equivalent minima\")\n",
+        "rho = 0.1\n",
+        "theta_bal = np.array([1.0, 1.0])\n",
+        "theta_unbal = np.array([3.0, 1.0 / 3.0])\n",
+        "\n",
+        "sharp_bal = 0.5 * rho**2 * np.max(np.linalg.eigvalsh(hess_uv(theta_bal)))\n",
+        "sharp_unbal = 0.5 * rho**2 * np.max(np.linalg.eigvalsh(hess_uv(theta_unbal)))\n",
+        "\n",
+        "print(\"Balanced proxy sharpness   =\", sharp_bal)\n",
+        "print(\"Unbalanced proxy sharpness =\", sharp_unbal)\n",
+        "check_true(\"Equivalent functions can have very different raw sharpness\", sharp_unbal > sharp_bal * 2)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Random perturbation loss increase around equivalent minima\")\n",
+        "rng = np.random.default_rng(42)\n",
+        "eps = rng.normal(size=(5000, 2))\n",
+        "eps /= np.linalg.norm(eps, axis=1, keepdims=True)\n",
+        "eps *= 0.05\n",
+        "\n",
+        "deltas_bal = np.array([loss_uv(theta_bal + e) - loss_uv(theta_bal) for e in eps])\n",
+        "deltas_unbal = np.array([loss_uv(theta_unbal + e) - loss_uv(theta_unbal) for e in eps])\n",
+        "\n",
+        "print(\"Mean perturbation loss increase (balanced)  =\", deltas_bal.mean())\n",
+        "print(\"Mean perturbation loss increase (unbalanced)=\", deltas_unbal.mean())\n",
+        "check_true(\"Unbalanced point is more sensitive in parameter space\", deltas_unbal.mean() > deltas_bal.mean())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Connectivity Beyond Straight Lines\n",
+        "\n",
+        "Mode connectivity asks whether two low-loss solutions can be joined by a low-loss curve even when the straight line between them rises.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Quadratic Bezier path search\")\n",
+        "best_c = None\n",
+        "best_barrier = np.inf\n",
+        "grid = np.linspace(0.3, 2.2, 120)\n",
+        "for c1 in grid:\n",
+        "    c2 = 1.0 / c1\n",
+        "    candidate = np.array([c1, c2])\n",
+        "    path = bezier_path(theta_a, candidate, theta_b, ts)\n",
+        "    barrier_val, _ = path_barrier(path, loss_uv)\n",
+        "    if barrier_val < best_barrier:\n",
+        "        best_barrier = barrier_val\n",
+        "        best_c = candidate.copy()\n",
+        "\n",
+        "print(\"Best Bezier control point on the manifold:\", best_c)\n",
+        "print(\"Best Bezier barrier:\", best_barrier)\n",
+        "check_true(\"Bezier search reduces the barrier relative to the straight line\", best_barrier < linear_barrier)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Line path and Bezier path in parameter space\")\n",
+        "bezier = bezier_path(theta_a, best_c, theta_b, ts)\n",
+        "bezier_barrier, bezier_vals = path_barrier(bezier, loss_uv)\n",
+        "\n",
+        "fig, axes = plt.subplots(1, 2, figsize=(13, 5))\n",
+        "\n",
+        "axes[0].contour(U, V, Z, levels=[0.0, 0.02, 0.1, 0.25, 0.5, 1.0], colors=COLORS[\"neutral\"], alpha=0.6)\n",
+        "axes[0].plot(linear_path[:, 0], linear_path[:, 1], label=\"Line path\", color=COLORS[\"secondary\"])\n",
+        "axes[0].plot(bezier[:, 0], bezier[:, 1], label=\"Bezier path\", color=COLORS[\"tertiary\"])\n",
+        "axes[0].scatter([theta_a[0], theta_b[0], best_c[0]], [theta_a[1], theta_b[1], best_c[1]], c=[COLORS[\"secondary\"], COLORS[\"secondary\"], COLORS[\"tertiary\"]], s=50)\n",
+        "axes[0].set_title(\"Paths in parameter space\")\n",
+        "axes[0].set_xlabel(\"u\")\n",
+        "axes[0].set_ylabel(\"v\")\n",
+        "axes[0].legend()\n",
+        "\n",
+        "axes[1].plot(ts, linear_vals, label=\"Line path\", color=COLORS[\"secondary\"])\n",
+        "axes[1].plot(ts, bezier_vals, label=\"Bezier path\", color=COLORS[\"tertiary\"])\n",
+        "axes[1].set_title(\"Loss along the paths\")\n",
+        "axes[1].set_xlabel(\"t\")\n",
+        "axes[1].set_ylabel(\"Loss\")\n",
+        "axes[1].legend()\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n",
+        "check_true(\"Bezier path has a lower maximum loss\", bezier_vals.max() < linear_vals.max())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Stability, Curvature, and Learning Rate\n",
+        "\n",
+        "For a quadratic objective with Hessian eigenvalues $\\lambda_i$, classical stability says gradient descent requires $\\eta < 2/\\lambda_{\\max}$.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Quadratic edge-of-stability toy model\")\n",
+        "H = np.diag([1.0, 10.0])\n",
+        "def quad_loss(theta):\n",
+        "    return 0.5 * theta @ H @ theta\n",
+        "\n",
+        "def quad_grad(theta):\n",
+        "    return H @ theta\n",
+        "\n",
+        "theta0 = np.array([1.0, 1.0])\n",
+        "etas = [0.15, 0.19, 0.21]\n",
+        "histories = {}\n",
+        "\n",
+        "for eta in etas:\n",
+        "    theta = theta0.copy()\n",
+        "    loss_hist = []\n",
+        "    for _ in range(40):\n",
+        "        loss_hist.append(quad_loss(theta))\n",
+        "        theta = theta - eta * quad_grad(theta)\n",
+        "    histories[eta] = np.array(loss_hist)\n",
+        "\n",
+        "for eta in etas:\n",
+        "    print(f\"eta={eta:.2f}, final loss={histories[eta][-1]:.6f}\")\n",
+        "\n",
+        "check_true(\"Above-boundary step becomes unstable\", histories[0.21][-1] > histories[0.19][-1] * 100)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Loss curves near the stability boundary\")\n",
+        "fig, ax = plt.subplots()\n",
+        "for eta, vals in histories.items():\n",
+        "    ax.plot(vals, label=rf\"$\\eta={eta}$\")\n",
+        "ax.set_yscale(\"log\")\n",
+        "ax.set_title(\"Quadratic GD near the stability threshold\")\n",
+        "ax.set_xlabel(\"Iteration\")\n",
+        "ax.set_ylabel(\"Loss\")\n",
+        "ax.legend()\n",
+        "plt.show()\n",
+        "print(\"Critical quantity eta * lambda_max:\")\n",
+        "for eta in etas:\n",
+        "    print(f\"  eta={eta:.2f} -> eta*lambda_max={eta * np.max(np.diag(H)):.2f}\")\n",
+        "check_true(\"The threshold is near 2/lambda_max\", abs(0.2 * np.max(np.diag(H)) - 2.0) < 1e-12)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. A Small Practical Checkpoint-Averaging Test\n",
+        "\n",
+        "Averaging works best when checkpoints already lie in a compatible low-loss corridor. Our toy loss lets us test both success and failure modes.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Averaging close compatible minima can work\")\n",
+        "theta_c = np.array([1.0, 1.0])\n",
+        "theta_d = np.array([1.1, 1 / 1.1])\n",
+        "avg_close = 0.5 * (theta_c + theta_d)\n",
+        "\n",
+        "print(\"Loss(theta_c) =\", loss_uv(theta_c))\n",
+        "print(\"Loss(theta_d) =\", loss_uv(theta_d))\n",
+        "print(\"Loss(average close pair) =\", loss_uv(avg_close))\n",
+        "check_true(\"Average of close compatible points stays low loss\", loss_uv(avg_close) < 5e-3)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Averaging distant symmetry-related minima can fail\")\n",
+        "avg_far = 0.5 * (theta_a + theta_b)\n",
+        "print(\"Loss(theta_a) =\", loss_uv(theta_a))\n",
+        "print(\"Loss(theta_b) =\", loss_uv(theta_b))\n",
+        "print(\"Loss(average far pair) =\", loss_uv(avg_far))\n",
+        "check_true(\"Average of distant equivalent meaningful points can leave the manifold\", loss_uv(avg_far) > 0.05)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "header(\"Takeaway summary\")\n",
+        "print(\"1. Saddles and flat directions are central in nonconvex high-dimensional problems.\")\n",
+        "print(\"2. Overparameterization creates families of solutions rather than one isolated optimum.\")\n",
+        "print(\"3. Raw parameter-space sharpness is not invariant to symmetry-preserving reparameterization.\")\n",
+        "print(\"4. Straight-line interpolation can be misleading; nonlinear low-loss paths may exist.\")\n",
+        "print(\"5. Stability depends strongly on local top curvature.\")\n",
+        "print(\"6. Practical averaging succeeds when checkpoints share a compatible low-loss corridor.\")\n",
+        "check_true(\"Notebook reached the final recap cell\", True)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/08-Optimization/07-Adaptive-Learning-Rate/exercises.ipynb
+++ b/08-Optimization/07-Adaptive-Learning-Rate/exercises.ipynb
@@ -1,0 +1,456 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "877e4fc4",
+   "metadata": {},
+   "source": [
+    "# Adaptive Learning Rate — Exercises\n",
+    "\n",
+    "8 exercises covering AdaGrad, RMSProp, Adam bias correction, AdamW, LAMB, Adafactor, and optimizer diagnostics.\n",
+    "\n",
+    "| Format | Description |\n",
+    "| --- | --- |\n",
+    "| **Problem** | Markdown cell with task description |\n",
+    "| **Your Solution** | Runnable scaffold with placeholders |\n",
+    "| **Solution** | Reference solution with checks |\n",
+    "\n",
+    "### Difficulty Levels\n",
+    "\n",
+    "| Level | Exercises | Focus |\n",
+    "| --- | --- | --- |\n",
+    "| ★ | 1-3 | Core mechanics |\n",
+    "| ★★ | 4-6 | Adam family and layerwise theory |\n",
+    "| ★★★ | 7-8 | Memory and diagnostics |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f09074ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import numpy.linalg as la\n",
+    "\n",
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    HAS_MPL = True\n",
+    "except ImportError:\n",
+    "    HAS_MPL = False\n",
+    "\n",
+    "np.set_printoptions(precision=6, suppress=True)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "def header(title):\n",
+    "    print(\"\\n\" + \"=\" * len(title))\n",
+    "    print(title)\n",
+    "    print(\"=\" * len(title))\n",
+    "\n",
+    "def check_close(name, got, expected, tol=1e-8):\n",
+    "    ok = np.allclose(got, expected, atol=tol, rtol=tol)\n",
+    "    print(f\"{'PASS' if ok else 'FAIL'} — {name}\")\n",
+    "    if not ok:\n",
+    "        print(\"  expected:\", expected)\n",
+    "        print(\"  got     :\", got)\n",
+    "    return ok\n",
+    "\n",
+    "def check_true(name, cond):\n",
+    "    print(f\"{'PASS' if cond else 'FAIL'} — {name}\")\n",
+    "    return cond\n",
+    "\n",
+    "print(\"Exercise setup complete.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c4517d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 1 ★ — AdaGrad by Hand\n",
+    "\n",
+    "Compute AdaGrad accumulators and updates for scalar gradients.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13f8a541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 1: AdaGrad by Hand\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25dd712a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 1: AdaGrad by Hand\")\n",
+    "grads = np.array([1.0, 2.0, 2.0])\n",
+    "r = 0.0\n",
+    "steps = []\n",
+    "theta = 0.0\n",
+    "for g in grads:\n",
+    "    r += g*g\n",
+    "    step = 0.1 * g / np.sqrt(r)\n",
+    "    theta -= step\n",
+    "    steps.append(step)\n",
+    "print(\"accumulator:\", r)\n",
+    "print(\"steps:\", steps)\n",
+    "print(\"theta:\", theta)\n",
+    "check_close(\"final accumulator\", r, 9.0)\n",
+    "check_true(\"steps shrink relative to raw gradient\", steps[-1] < 0.1 * grads[-1])\n",
+    "print(\"\\nTakeaway: AdaGrad remembers all squared gradients, so frequent coordinates receive smaller effective steps.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f8fe65e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 2 ★ — RMSProp Forgetting\n",
+    "\n",
+    "Track exponential second moments after a gradient scale change.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92950dd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 2: RMSProp Forgetting\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76805508",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 2: RMSProp Forgetting\")\n",
+    "grads = np.r_[np.ones(5), 5*np.ones(5), np.ones(10)]\n",
+    "r = 0.0\n",
+    "track = []\n",
+    "for g in grads:\n",
+    "    r = 0.9*r + 0.1*g*g\n",
+    "    track.append(r)\n",
+    "print(\"tracked second moments:\", np.round(track, 4))\n",
+    "check_true(\"spike increases second moment\", track[9] > track[4])\n",
+    "check_true(\"forgetting lowers it after spike\", track[-1] < track[9])\n",
+    "print(\"\\nTakeaway: RMSProp keeps recent scale information without AdaGrad's unbounded accumulation.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b99a026e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 3 ★ — Adam Bias Correction\n",
+    "\n",
+    "Verify corrected moments for a constant gradient.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09cc0d75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 3: Adam Bias Correction\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03b8c2c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 3: Adam Bias Correction\")\n",
+    "g = 4.0\n",
+    "b1, b2 = 0.9, 0.999\n",
+    "m = v = 0.0\n",
+    "for t in range(1, 4):\n",
+    "    m = b1*m + (1-b1)*g\n",
+    "    v = b2*v + (1-b2)*g*g\n",
+    "mhat = m / (1-b1**t)\n",
+    "vhat = v / (1-b2**t)\n",
+    "print(\"mhat:\", mhat)\n",
+    "print(\"vhat:\", vhat)\n",
+    "check_close(\"corrected first moment\", mhat, g)\n",
+    "check_close(\"corrected second moment\", vhat, g*g)\n",
+    "print(\"\\nTakeaway: bias correction removes the zero-initialization bias for constant gradients.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfe4fa6c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 4 ★★ — Effective Learning Rates\n",
+    "\n",
+    "Compare coordinatewise effective learning rates.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9746f7f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 4: Effective Learning Rates\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9b18a6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 4: Effective Learning Rates\")\n",
+    "v = np.array([1e-4, 1e-2, 1.0, 100.0])\n",
+    "eff = 1e-3 / (np.sqrt(v) + 1e-8)\n",
+    "print(\"effective learning rates:\", eff)\n",
+    "check_true(\"effective LR decreases with second moment\", np.all(np.diff(eff) < 0))\n",
+    "check_close(\"largest effective LR\", eff[0], 0.1, tol=1e-5)\n",
+    "print(\"\\nTakeaway: adaptive optimizers still have learning rates; they are coordinatewise effective learning rates.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbcd1b69",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 5 ★★ — AdamW vs Coupled L2\n",
+    "\n",
+    "Show coupled and decoupled decay differ.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "326d4e46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 5: AdamW vs Coupled L2\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f54bcf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 5: AdamW vs Coupled L2\")\n",
+    "theta = np.array([1.0, 10.0])\n",
+    "g = np.array([0.1, 0.1])\n",
+    "v = np.array([1e-4, 1.0])\n",
+    "lr, wd = 0.01, 0.1\n",
+    "coupled = theta - lr * (g + wd*theta) / (np.sqrt(v) + 1e-8)\n",
+    "decoupled = (1 - lr*wd) * theta - lr * g / (np.sqrt(v) + 1e-8)\n",
+    "print(\"coupled:\", coupled)\n",
+    "print(\"decoupled:\", decoupled)\n",
+    "check_true(\"updates differ\", not np.allclose(coupled, decoupled))\n",
+    "print(\"\\nTakeaway: AdamW decouples weight decay from adaptive gradient preconditioning.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e54c13a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 6 ★★ — LAMB Trust Ratio\n",
+    "\n",
+    "Compute layerwise trust ratios.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69a1258a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 6: LAMB Trust Ratio\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af3d29b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 6: LAMB Trust Ratio\")\n",
+    "theta = np.array([3.0, 4.0])\n",
+    "u = np.array([0.3, 0.4])\n",
+    "trust = la.norm(theta) / (la.norm(u) + 1e-8)\n",
+    "scaled_norm = la.norm(trust * u)\n",
+    "print(\"trust ratio:\", trust)\n",
+    "print(\"scaled update norm:\", scaled_norm)\n",
+    "check_close(\"trust ratio\", trust, 10.0, tol=1e-6)\n",
+    "check_close(\"scaled update norm matches parameter norm\", scaled_norm, la.norm(theta), tol=1e-6)\n",
+    "print(\"\\nTakeaway: trust ratios control layerwise update scale relative to parameter scale.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6be6aa23",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 7 ★★★ — Adafactor Memory\n",
+    "\n",
+    "Compare full and factored second-moment memory.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4a4b877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 7: Adafactor Memory\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2f22070",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 7: Adafactor Memory\")\n",
+    "m, n = 4096, 16384\n",
+    "full = m * n\n",
+    "factored = m + n\n",
+    "savings = full / factored\n",
+    "print(\"full entries:\", full)\n",
+    "print(\"factored entries:\", factored)\n",
+    "print(\"savings factor:\", savings)\n",
+    "check_true(\"factored state is much smaller\", savings > 1000)\n",
+    "print(\"\\nTakeaway: factored second moments can reduce optimizer state from O(mn) to O(m+n).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efe90fb2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercise 8 ★★★ — Optimizer Diagnostics\n",
+    "\n",
+    "Diagnose a synthetic failed training run.\n",
+    "\n",
+    "Fill the scaffold, then compare with the reference solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a04000a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your Solution — Exercise 8: Optimizer Diagnostics\n",
+    "# Replace None with your computation.\n",
+    "answer = None\n",
+    "print(\"answer:\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36863366",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header(\"Exercise 8: Optimizer Diagnostics\")\n",
+    "grad_norm = np.array([1.0, 1.2, 1.4, 20.0, 25.0])\n",
+    "update_ratio = np.array([0.001, 0.0012, 0.0013, 0.08, 0.12])\n",
+    "effective_lr = np.array([1e-3, 1e-3, 1e-3, 5e-2, 8e-2])\n",
+    "failure = (grad_norm[-1] > 10 * np.median(grad_norm[:3])) and (update_ratio[-1] > 0.05)\n",
+    "print(\"failure detected:\", failure)\n",
+    "print(\"suggested fix: lower LR, inspect loss scaling, add clipping or increase epsilon\")\n",
+    "check_true(\"synthetic run shows optimizer instability\", failure)\n",
+    "print(\"\\nTakeaway: gradient norm, update ratio, and effective LR often expose failures before loss alone explains them.\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/08-Optimization/07-Adaptive-Learning-Rate/notes.md
+++ b/08-Optimization/07-Adaptive-Learning-Rate/notes.md
@@ -1,0 +1,971 @@
+[← Back to Optimization](../README.md) | [Previous: Optimization Landscape ←](../06-Optimization-Landscape/notes.md) | [Next: Regularization Methods →](../08-Regularization-Methods/notes.md)
+
+---
+
+# Adaptive Learning Rate
+
+> _"A good optimizer does not merely follow the gradient; it decides how much to trust each coordinate of it."_
+
+## Overview
+
+Adaptive learning-rate methods modify gradient descent by giving different coordinates, parameters, layers, or blocks different effective step sizes. Instead of applying one scalar learning rate $\eta$ to every coordinate, they maintain running statistics of past gradients and use those statistics to rescale future updates. This is the mathematical idea behind AdaGrad, RMSProp, Adam, AdamW, Adafactor, LARS, and LAMB.
+
+This section is the canonical home for per-parameter adaptation in the Optimization chapter. The stochastic gradients themselves are covered in [Stochastic Optimization](../05-Stochastic-Optimization/notes.md), the geometry of the loss surface is covered in [Optimization Landscape](../06-Optimization-Landscape/notes.md), and external time-varying schedules such as warmup and cosine decay belong to [Learning Rate Schedules](../10-Learning-Rate-Schedules/notes.md). Here the focus is the optimizer's internal adaptation: how gradient history changes the update direction and scale.
+
+For modern AI, this topic is not optional. AdamW is the default optimizer for transformers and LLM fine-tuning; Adafactor reduces optimizer-state memory for very large models; LAMB and LARS were designed for large-batch training; and new optimizer proposals are usually judged against AdamW. To use these tools well, you need more than a recipe. You need to understand effective learning rates, moment estimates, bias correction, decoupled weight decay, numerical stabilizers, and optimizer diagnostics.
+
+## Prerequisites
+
+- **Gradient descent and momentum** — update rules, step-size stability, Polyak momentum — [Gradient Descent](../02-Gradient-Descent/notes.md)
+- **Second-order and preconditioned methods** — Newton directions, diagonal approximations, natural-gradient intuition — [Second-Order Methods](../03-Second-Order-Methods/notes.md)
+- **Stochastic gradients** — mini-batch estimates, gradient noise, batch size scaling — [Stochastic Optimization](../05-Stochastic-Optimization/notes.md)
+- **Optimization landscapes** — curvature, sharpness, flatness, and instability diagnostics — [Optimization Landscape](../06-Optimization-Landscape/notes.md)
+- **Vector and matrix notation** — elementwise operations, diagonal matrices, norms — [Linear Algebra Basics](../../02-Linear-Algebra-Basics/README.md)
+
+## Companion Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [theory.ipynb](theory.ipynb) | Interactive demonstrations of AdaGrad, RMSProp, Adam, AdamW, LAMB, Adafactor memory, effective learning rates, and optimizer diagnostics |
+| [exercises.ipynb](exercises.ipynb) | 8 graded exercises covering adaptive updates, bias correction, decoupled weight decay, trust ratios, memory cost, and practical diagnosis |
+
+## Learning Objectives
+
+After completing this section, you will:
+
+1. Explain why one global learning rate is inefficient for ill-conditioned and sparse-gradient problems
+2. Write adaptive optimizers as diagonal preconditioned gradient methods
+3. Derive AdaGrad, RMSProp, Adam, AdamW, AMSGrad, Adafactor, LARS, and LAMB update rules
+4. Compute effective per-coordinate learning rates from optimizer state
+5. Explain Adam's first-moment, second-moment, and bias-correction terms
+6. Distinguish coupled $L_2$ regularization from decoupled weight decay in AdamW
+7. Analyze optimizer-state memory costs for billion-parameter models
+8. Interpret trust ratios in layerwise adaptive methods such as LARS and LAMB
+9. Diagnose training instability using gradient norms, update norms, parameter norms, and effective learning rates
+10. Choose reasonable optimizer defaults for transformers, sparse models, reinforcement learning, and large-batch training
+11. Separate stable optimizer theory from empirical 2026-era optimizer fashion
+
+---
+
+## Table of Contents
+
+- [1. Intuition](#1-intuition)
+  - [1.1 Why One Global Learning Rate Fails](#11-why-one-global-learning-rate-fails)
+  - [1.2 Per-Parameter Learning Rates as Diagonal Preconditioning](#12-per-parameter-learning-rates-as-diagonal-preconditioning)
+  - [1.3 Sparse Gradients, Noisy Gradients, and Ill-Conditioning](#13-sparse-gradients-noisy-gradients-and-ill-conditioning)
+  - [1.4 Optimizer Lineage](#14-optimizer-lineage)
+  - [1.5 Why Adaptive Optimizers Matter for Transformers and LLMs](#15-why-adaptive-optimizers-matter-for-transformers-and-llms)
+- [2. Formal Definitions](#2-formal-definitions)
+  - [2.1 Base Update Rule and Effective Learning Rate](#21-base-update-rule-and-effective-learning-rate)
+  - [2.2 Gradient Accumulators and Second-Moment Estimates](#22-gradient-accumulators-and-second-moment-estimates)
+  - [2.3 Diagonal Preconditioners](#23-diagonal-preconditioners)
+  - [2.4 Bias Correction and Initialization Effects](#24-bias-correction-and-initialization-effects)
+  - [2.5 Optimizer State, Memory Cost, and Numerical Stabilizers](#25-optimizer-state-memory-cost-and-numerical-stabilizers)
+- [3. Core Theory I: AdaGrad and RMSProp](#3-core-theory-i-adagrad-and-rmsprop)
+  - [3.1 AdaGrad Derivation and Sparse-Feature Behavior](#31-adagrad-derivation-and-sparse-feature-behavior)
+  - [3.2 AdaGrad Regret Intuition and Diminishing Steps](#32-adagrad-regret-intuition-and-diminishing-steps)
+  - [3.3 RMSProp as Exponential Forgetting](#33-rmsprop-as-exponential-forgetting)
+  - [3.4 Choosing Epsilon and Accumulator Decay](#34-choosing-epsilon-and-accumulator-decay)
+  - [3.5 AdaDelta and Practical Historical Variants](#35-adadelta-and-practical-historical-variants)
+- [4. Core Theory II: Adam Family](#4-core-theory-ii-adam-family)
+  - [4.1 Adam as Momentum plus RMSProp](#41-adam-as-momentum-plus-rmsprop)
+  - [4.2 First Moment, Second Moment, and Bias Correction](#42-first-moment-second-moment-and-bias-correction)
+  - [4.3 Effective Step Size and Update Normalization](#43-effective-step-size-and-update-normalization)
+  - [4.4 Adam Convergence Caveats and AMSGrad](#44-adam-convergence-caveats-and-amsgrad)
+  - [4.5 AdamW and Decoupled Weight Decay](#45-adamw-and-decoupled-weight-decay)
+- [5. Core Theory III: Layerwise and Memory-Efficient Adaptation](#5-core-theory-iii-layerwise-and-memory-efficient-adaptation)
+  - [5.1 LARS and LAMB for Large-Batch Training](#51-lars-and-lamb-for-large-batch-training)
+  - [5.2 Trust Ratio and Layerwise Update Scaling](#52-trust-ratio-and-layerwise-update-scaling)
+  - [5.3 Adafactor and Factored Second-Moment State](#53-adafactor-and-factored-second-moment-state)
+  - [5.4 Optimizer State Memory in Large Models](#54-optimizer-state-memory-in-large-models)
+  - [5.5 When Layerwise Adaptation Helps or Hurts](#55-when-layerwise-adaptation-helps-or-hurts)
+- [6. Advanced Topics](#6-advanced-topics)
+  - [6.1 Adaptive Methods as Diagonal Natural-Gradient Approximations](#61-adaptive-methods-as-diagonal-natural-gradient-approximations)
+  - [6.2 Relationship to Curvature and Preconditioning](#62-relationship-to-curvature-and-preconditioning)
+  - [6.3 Sign-Based and Low-Memory Optimizers](#63-sign-based-and-low-memory-optimizers)
+  - [6.4 Structured Preconditioners](#64-structured-preconditioners)
+  - [6.5 Stability Diagnostics](#65-stability-diagnostics)
+- [7. Applications in Machine Learning](#7-applications-in-machine-learning)
+  - [7.1 AdamW for Transformer Pretraining and Fine-Tuning](#71-adamw-for-transformer-pretraining-and-fine-tuning)
+  - [7.2 Sparse Embeddings and Recommendation Models](#72-sparse-embeddings-and-recommendation-models)
+  - [7.3 Reinforcement Learning and Non-Stationary Objectives](#73-reinforcement-learning-and-non-stationary-objectives)
+  - [7.4 Large-Batch Training with LAMB](#74-large-batch-training-with-lamb)
+  - [7.5 Practical Optimizer Selection Checklist](#75-practical-optimizer-selection-checklist)
+- [8. Common Mistakes](#8-common-mistakes)
+- [9. Exercises](#9-exercises)
+- [10. Why This Matters for AI (2026 Perspective)](#10-why-this-matters-for-ai-2026-perspective)
+- [11. Conceptual Bridge](#11-conceptual-bridge)
+- [References](#references)
+
+---
+
+## 1. Intuition
+
+### 1.1 Why One Global Learning Rate Fails
+
+Vanilla gradient descent uses one scalar learning rate:
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t - \eta \mathbf{g}_t,
+$$
+
+where $\mathbf{g}_t = \nabla \mathcal{L}(\boldsymbol{\theta}_t)$ or a mini-batch estimate of it. This treats every coordinate of $\boldsymbol{\theta}$ as if it had the same scale, curvature, noise level, and frequency of update. Real neural networks do not behave that way.
+
+In an embedding table, some token vectors may receive gradients constantly while rare-token vectors receive gradients only occasionally. In a transformer, attention projections, MLP matrices, normalization parameters, and output heads can have very different gradient statistics. In an ill-conditioned quadratic, one coordinate may be steep and another shallow. A single $\eta$ must be small enough not to explode in the steep coordinate, but that makes progress painfully slow in the shallow coordinate.
+
+The core motivation for adaptive learning rates is therefore simple:
+
+$$
+\text{different coordinates need different effective step sizes.}
+$$
+
+```text
+ONE ETA VS MANY EFFECTIVE ETAS
+════════════════════════════════════════════════════════════════════════
+
+  Single global step:
+      theta_{t+1} = theta_t - eta * g_t
+
+  Adaptive diagonal step:
+      theta_{t+1} = theta_t - eta * D_t^{-1/2} * g_t
+
+  coordinate with large historical gradients  -> smaller effective LR
+  coordinate with small historical gradients  -> larger effective LR
+  sparse coordinate updated rarely            -> not drowned by common features
+
+════════════════════════════════════════════════════════════════════════
+```
+
+**For AI:** This is why AdamW often trains transformers more easily than SGD with momentum. It automatically rescales parameters whose gradients live on different numerical scales. That does not make it magic, but it removes a large amount of manual learning-rate tuning.
+
+### 1.2 Per-Parameter Learning Rates as Diagonal Preconditioning
+
+Adaptive methods can be understood as diagonal preconditioned gradient descent. Instead of moving in direction $-\mathbf{g}_t$, they move in direction
+
+$$
+-P_t \mathbf{g}_t,
+$$
+
+where $P_t$ is usually a positive diagonal matrix:
+
+$$
+P_t = \operatorname{diag}(p_{t,1},\dots,p_{t,d}).
+$$
+
+For Adam-like methods, $p_{t,i}$ is roughly the inverse square root of a running average of squared gradients:
+
+$$
+p_{t,i} \approx \frac{1}{\sqrt{v_{t,i}}+\epsilon}.
+$$
+
+The update becomes
+
+$$
+\theta_{t+1,i}
+= \theta_{t,i} - \eta \frac{m_{t,i}}{\sqrt{v_{t,i}}+\epsilon}.
+$$
+
+Here $m_t$ is a first-moment estimate, $v_t$ is a second-moment estimate, and $\epsilon$ is a numerical stabilizer. The term
+
+$$
+\eta_{t,i}^{\mathrm{eff}} = \frac{\eta}{\sqrt{v_{t,i}}+\epsilon}
+$$
+
+is the effective learning rate for coordinate $i$ before momentum and bias correction.
+
+This diagonal view also explains the connection to second-order methods. Newton's method uses $H^{-1}$, the inverse Hessian. Natural gradient uses a Fisher inverse. Adaptive methods use something much cheaper: a diagonal statistic based on gradient history. They are not exact second-order methods, but they borrow the same idea: rescale the gradient by local geometry.
+
+### 1.3 Sparse Gradients, Noisy Gradients, and Ill-Conditioning
+
+Adaptive methods are especially useful in three regimes.
+
+First, **sparse gradients**. In language models and recommendation systems, some parameters are updated rarely. AdaGrad was designed to give rare but informative coordinates larger relative updates because their accumulated squared-gradient history grows slowly.
+
+Second, **noisy gradients**. In reinforcement learning, generative modeling, and small-batch training, gradient estimates can be highly variable. Running moment estimates smooth the update and reduce sensitivity to any single noisy mini-batch.
+
+Third, **ill-conditioning**. When different directions have different curvature, vanilla gradient descent zigzags. A diagonal preconditioner cannot fix all curvature, because it ignores correlations between coordinates, but it can reduce scale mismatch when the main problem is coordinatewise.
+
+Examples:
+
+- Sparse word embeddings: AdaGrad or Adam can help rare tokens move.
+- Transformer blocks: AdamW stabilizes heterogeneous parameter groups.
+- Large-batch BERT-style training: LAMB scales layer updates by a trust ratio.
+- Memory-constrained training: Adafactor approximates the second moment using factored state.
+
+Non-examples:
+
+- If all coordinates have identical scale and curvature, adaptivity may add little.
+- If the main curvature problem is strong off-diagonal correlation, diagonal methods may be insufficient.
+
+### 1.4 Optimizer Lineage
+
+The family tree is easier to understand if each method answers one specific complaint about the previous method.
+
+```text
+FROM SGD TO ADAMW
+════════════════════════════════════════════════════════════════════════
+
+  SGD
+    problem: one global step size
+       |
+       v
+  AdaGrad
+    accumulates squared gradients forever
+    good for sparsity, but steps can decay too much
+       |
+       v
+  RMSProp
+    uses exponential moving average of squared gradients
+    fixes AdaGrad's never-forget behavior
+       |
+       v
+  Adam
+    RMSProp-style second moment + momentum first moment + bias correction
+       |
+       v
+  AdamW
+    Adam with decoupled weight decay
+    default for many transformer and LLM workloads
+       |
+       v
+  LAMB / Adafactor / newer variants
+    layerwise scaling, memory efficiency, and workload-specific refinements
+
+════════════════════════════════════════════════════════════════════════
+```
+
+Historically, AdaGrad came from online convex optimization, RMSProp from neural-network training practice, Adam from stochastic optimization with moment estimates, AdamW from the observation that $L_2$ regularization and weight decay are not equivalent for adaptive methods, and LAMB from large-batch BERT training.
+
+### 1.5 Why Adaptive Optimizers Matter for Transformers and LLMs
+
+Transformers are optimizer-sensitive for several reasons:
+
+- their parameter groups have very different gradient scales
+- token embeddings create sparse and frequency-skewed updates
+- attention and MLP blocks can have different curvature statistics
+- normalization parameters and biases usually should not receive the same weight decay as large weight matrices
+- mixed precision makes numerical stability more important
+- large-batch training changes gradient noise and update norms
+
+AdamW works well because it combines three useful behaviors:
+
+1. momentum through the first moment $m_t$
+2. coordinatewise scaling through the second moment $v_t$
+3. decoupled weight decay that avoids mixing regularization with adaptive preconditioning
+
+The practical lesson is not "always use AdamW." The practical lesson is: AdamW is the baseline you must understand before evaluating alternatives.
+
+---
+
+## 2. Formal Definitions
+
+### 2.1 Base Update Rule and Effective Learning Rate
+
+Let $\boldsymbol{\theta}_t \in \mathbb{R}^d$ be parameters and $\mathbf{g}_t$ be a stochastic gradient at step $t$. A coordinatewise adaptive method often has the form
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t - \eta \, \mathbf{s}_t,
+$$
+
+where the update direction $\mathbf{s}_t$ is not simply $\mathbf{g}_t$. For diagonal adaptive methods,
+
+$$
+\mathbf{s}_t = A_t^{-1/2}\mathbf{u}_t,
+$$
+
+where $A_t$ is diagonal and nonnegative, and $\mathbf{u}_t$ is usually a raw gradient or a momentum-smoothed gradient.
+
+The **effective learning rate** for coordinate $i$ is the scalar multiplying the update signal:
+
+$$
+\eta_{t,i}^{\mathrm{eff}}
+= \frac{\eta}{\sqrt{a_{t,i}}+\epsilon}.
+$$
+
+This quantity is diagnostic gold. If $\eta_{t,i}^{\mathrm{eff}}$ collapses to nearly zero, the parameter may stop learning. If it becomes too large because $a_{t,i}$ is tiny, updates can explode.
+
+### 2.2 Gradient Accumulators and Second-Moment Estimates
+
+Adaptive optimizers rely on gradient history. The two most common state variables are:
+
+$$
+m_t \approx \mathbb{E}[\mathbf{g}_t],
+\qquad
+v_t \approx \mathbb{E}[\mathbf{g}_t \odot \mathbf{g}_t].
+$$
+
+Here $\odot$ denotes elementwise multiplication. $m_t$ tracks direction; $v_t$ tracks magnitude. For Adam,
+
+$$
+m_t = \beta_1 m_{t-1} + (1-\beta_1)\mathbf{g}_t,
+$$
+
+and
+
+$$
+v_t = \beta_2 v_{t-1} + (1-\beta_2)(\mathbf{g}_t \odot \mathbf{g}_t).
+$$
+
+The hyperparameters $\beta_1$ and $\beta_2$ are decay rates. Large values mean long memory. Common defaults are $\beta_1=0.9$ and $\beta_2=0.999$, though LLM training often uses $\beta_2$ values such as $0.95$ or $0.98$ depending on scale, batch, and schedule.
+
+### 2.3 Diagonal Preconditioners
+
+A **preconditioner** changes the geometry of gradient descent. In ordinary gradient descent,
+
+$$
+\Delta \boldsymbol{\theta}_t = -\eta \mathbf{g}_t.
+$$
+
+With a preconditioner $P_t$,
+
+$$
+\Delta \boldsymbol{\theta}_t = -\eta P_t \mathbf{g}_t.
+$$
+
+If $P_t$ is diagonal, this is coordinatewise rescaling:
+
+$$
+\Delta \theta_{t,i}
+= -\eta p_{t,i} g_{t,i}.
+$$
+
+AdaGrad uses a cumulative diagonal preconditioner. RMSProp and Adam use exponential moving averages. Adafactor uses a factored approximation to avoid storing a full $v_t$ tensor. Shampoo uses richer matrix preconditioners, but that belongs mostly to the structured preconditioning bridge rather than the core diagonal family.
+
+### 2.4 Bias Correction and Initialization Effects
+
+Moment estimates initialized at zero are biased toward zero in early steps. If
+
+$$
+m_t = \beta_1 m_{t-1} + (1-\beta_1)\mathbf{g}_t,
+\qquad
+m_0=\mathbf{0},
+$$
+
+and the gradient is constant $\mathbf{g}$, then
+
+$$
+m_t = (1-\beta_1^t)\mathbf{g}.
+$$
+
+So Adam uses
+
+$$
+\widehat{m}_t = \frac{m_t}{1-\beta_1^t},
+\qquad
+\widehat{v}_t = \frac{v_t}{1-\beta_2^t}.
+$$
+
+The corrected Adam update is
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t
+- \eta \frac{\widehat{m}_t}{\sqrt{\widehat{v}_t}+\epsilon}.
+$$
+
+Without bias correction, the early steps can be mis-scaled. This is especially relevant during warmup, where optimizer state and schedule both change quickly.
+
+### 2.5 Optimizer State, Memory Cost, and Numerical Stabilizers
+
+Adaptive methods are not free. For a parameter vector with $d$ scalar parameters:
+
+| Optimizer | State per parameter | Main state |
+| --- | ---: | --- |
+| SGD | $0$ | none |
+| SGD + momentum | $1$ | velocity |
+| AdaGrad | $1$ | cumulative squared gradients |
+| RMSProp | $1$ | EMA squared gradients |
+| Adam / AdamW | $2$ | first and second moments |
+| Adafactor | sublinear for matrices | factored second moment |
+
+For a billion parameters in FP32, one state tensor costs about $4$ GB. AdamW with two FP32 state tensors costs about $8$ GB just for optimizer state, before parameters, gradients, activations, and distributed optimizer sharding.
+
+The stabilizer $\epsilon$ also matters:
+
+$$
+\frac{1}{\sqrt{v_{t,i}}+\epsilon}.
+$$
+
+If $\epsilon$ is too small, coordinates with tiny $v_{t,i}$ can take huge steps. If it is too large, adaptivity is damped. Framework defaults are useful starting points, not laws.
+
+---
+
+## 3. Core Theory I: AdaGrad and RMSProp
+
+### 3.1 AdaGrad Derivation and Sparse-Feature Behavior
+
+AdaGrad accumulates squared gradients:
+
+$$
+\mathbf{r}_t = \mathbf{r}_{t-1} + \mathbf{g}_t \odot \mathbf{g}_t,
+\qquad
+\mathbf{r}_0 = \mathbf{0}.
+$$
+
+Then it updates
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t
+- \eta \frac{\mathbf{g}_t}{\sqrt{\mathbf{r}_t}+\epsilon}.
+$$
+
+For coordinate $i$,
+
+$$
+\eta_{t,i}^{\mathrm{eff}}
+= \frac{\eta}{\sqrt{\sum_{\tau=1}^t g_{\tau,i}^2}+\epsilon}.
+$$
+
+Frequent coordinates accumulate large denominators and receive smaller future steps. Rare coordinates accumulate slowly and keep larger effective learning rates. This is exactly what you want for sparse features.
+
+**Examples.**
+
+1. Text classification with rare words: rare features should not be ignored merely because they update less often.
+2. Recommendation embeddings: infrequent users or items need meaningful updates when observed.
+3. Online learning: the feature distribution may be long-tailed and nonstationary.
+
+**Non-examples.**
+
+1. Dense homogeneous gradients: AdaGrad's sparsity advantage may not matter.
+2. Long deep-network training: the denominator can grow forever, making effective steps too small.
+
+### 3.2 AdaGrad Regret Intuition and Diminishing Steps
+
+AdaGrad has strong roots in online convex optimization. The regret analysis shows that coordinatewise adaptation can improve bounds when gradients are sparse or unevenly distributed. The informal idea is:
+
+$$
+\sum_{t=1}^T g_{t,i}^2
+$$
+
+measures how much coordinate $i$ has mattered historically. Coordinates that matter often get cautious updates; coordinates that matter rarely retain larger steps.
+
+The same property is also AdaGrad's weakness. Because $\mathbf{r}_t$ only grows,
+
+$$
+\eta_{t,i}^{\mathrm{eff}} \to 0
+$$
+
+if coordinate $i$ receives persistent nonzero gradients. This can prematurely stop learning in long nonconvex training runs.
+
+### 3.3 RMSProp as Exponential Forgetting
+
+RMSProp replaces AdaGrad's cumulative sum with exponential forgetting:
+
+$$
+\mathbf{r}_t
+= \rho \mathbf{r}_{t-1}
++ (1-\rho)(\mathbf{g}_t \odot \mathbf{g}_t).
+$$
+
+The update is
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t
+- \eta \frac{\mathbf{g}_t}{\sqrt{\mathbf{r}_t}+\epsilon}.
+$$
+
+Now the optimizer remembers recent gradient scale but eventually forgets old scale. This is more suitable for nonstationary objectives and long training runs.
+
+RMSProp is historically important because Adam is essentially RMSProp plus momentum plus bias correction.
+
+### 3.4 Choosing Epsilon and Accumulator Decay
+
+The decay $\rho$ controls the time horizon. The effective memory length is roughly
+
+$$
+\frac{1}{1-\rho}.
+$$
+
+So $\rho=0.9$ remembers roughly $10$ steps, while $\rho=0.99$ remembers roughly $100$ steps. Adam's $\beta_2=0.999$ remembers even longer.
+
+The stabilizer $\epsilon$ has two roles:
+
+- prevent division by zero
+- limit the maximum effective learning rate
+
+For AI systems, $\epsilon$ can interact with mixed precision. A value that is harmless in FP32 may behave differently with BF16 or FP16 state if implementation details change. Good frameworks usually keep optimizer state in FP32 for this reason.
+
+### 3.5 AdaDelta and Practical Historical Variants
+
+AdaDelta was designed to reduce manual learning-rate sensitivity by tracking both squared gradients and squared updates. Its practical influence is historical: it helped establish the idea that adaptive update magnitudes could be controlled by running statistics.
+
+The modern lesson is not that AdaDelta should be your default optimizer. The lesson is that every adaptive method chooses:
+
+- what statistic to track
+- how long to remember it
+- whether to track gradients, updates, or both
+- how to stabilize division
+- how much state memory to pay
+
+Once you see optimizers through this lens, new variants become less mysterious.
+
+---
+
+## 4. Core Theory II: Adam Family
+
+### 4.1 Adam as Momentum plus RMSProp
+
+Adam tracks two exponential moving averages:
+
+$$
+m_t = \beta_1 m_{t-1} + (1-\beta_1)\mathbf{g}_t,
+$$
+
+$$
+v_t = \beta_2 v_{t-1} + (1-\beta_2)(\mathbf{g}_t \odot \mathbf{g}_t).
+$$
+
+After bias correction,
+
+$$
+\widehat{m}_t = \frac{m_t}{1-\beta_1^t},
+\qquad
+\widehat{v}_t = \frac{v_t}{1-\beta_2^t}.
+$$
+
+The update is
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t
+- \eta \frac{\widehat{m}_t}{\sqrt{\widehat{v}_t}+\epsilon}.
+$$
+
+Adam's first moment behaves like momentum. Its second moment behaves like RMSProp. Bias correction fixes the fact that both estimates start at zero.
+
+### 4.2 First Moment, Second Moment, and Bias Correction
+
+The first moment $m_t$ smooths direction. It reduces update jitter and accumulates persistent descent directions. The second moment $v_t$ smooths scale. It prevents coordinates with large historical gradients from dominating the update.
+
+For a constant scalar gradient $g$, the uncorrected moments are:
+
+$$
+m_t = (1-\beta_1^t)g,
+\qquad
+v_t = (1-\beta_2^t)g^2.
+$$
+
+Bias correction recovers $g$ and $g^2$ exactly in this idealized case:
+
+$$
+\widehat{m}_t=g,
+\qquad
+\widehat{v}_t=g^2.
+$$
+
+That explains why bias correction matters most early in training.
+
+### 4.3 Effective Step Size and Update Normalization
+
+Ignoring $\epsilon$, if the gradient is constant and bias correction is applied, Adam's scalar update approximately becomes
+
+$$
+-\eta \frac{g}{\sqrt{g^2}}
+= -\eta \operatorname{sign}(g).
+$$
+
+This sign-like behavior is one reason Adam is robust to gradient scale, but it is also a caution. Adam does not simply take a smaller step when gradients are small. It normalizes by estimated magnitude.
+
+In vector form, Adam can produce update directions that differ substantially from SGD. This is useful when scale mismatch is real, but it can be harmful when the second-moment estimate is noisy or when normalization amplifies unimportant coordinates.
+
+### 4.4 Adam Convergence Caveats and AMSGrad
+
+Adam works extremely well in practice, but its original convergence story is subtler than the headline suggests. Reddi, Kale, and Kumar showed examples where Adam can fail to converge under certain online convex settings because the adaptive denominator can change in problematic ways.
+
+AMSGrad modifies Adam by keeping a nondecreasing second-moment maximum:
+
+$$
+\widehat{v}_t^{\max}
+= \max(\widehat{v}_{t-1}^{\max}, \widehat{v}_t),
+$$
+
+and updates with $\widehat{v}_t^{\max}$ in the denominator. This prevents the effective learning rate from increasing in a way that breaks the proof.
+
+In deep learning practice, AMSGrad is not universally better than Adam. Its main value in this curriculum is conceptual: adaptive methods need stability conditions, not just appealing formulas.
+
+### 4.5 AdamW and Decoupled Weight Decay
+
+Standard $L_2$ regularization adds a penalty to the loss:
+
+$$
+\mathcal{L}_{\lambda}(\boldsymbol{\theta})
+= \mathcal{L}(\boldsymbol{\theta})
++ \frac{\lambda}{2}\lVert \boldsymbol{\theta} \rVert_2^2.
+$$
+
+The gradient becomes
+
+$$
+\nabla \mathcal{L}_{\lambda}(\boldsymbol{\theta})
+= \nabla \mathcal{L}(\boldsymbol{\theta}) + \lambda \boldsymbol{\theta}.
+$$
+
+For vanilla SGD, this is equivalent to weight decay under common conventions. For Adam, it is not equivalent because $\lambda \boldsymbol{\theta}$ enters the adaptive preconditioner. Large and small coordinates get decayed through the same nonlinear denominator used for gradients.
+
+AdamW decouples decay from the adaptive gradient step:
+
+$$
+\boldsymbol{\theta}_{t+1}
+= (1-\eta\lambda)\boldsymbol{\theta}_t
+- \eta \frac{\widehat{m}_t}{\sqrt{\widehat{v}_t}+\epsilon}.
+$$
+
+This separation is one of the most important optimizer details in modern transformer training.
+
+> **Forward link:** The broader regularization interpretation of weight decay belongs to [Regularization Methods](../08-Regularization-Methods/notes.md). Here the focus is the optimizer-level distinction between coupled and decoupled decay.
+
+---
+
+## 5. Core Theory III: Layerwise and Memory-Efficient Adaptation
+
+### 5.1 LARS and LAMB for Large-Batch Training
+
+Large-batch training changes the scale of optimization. Gradient noise decreases, throughput improves, and learning-rate scaling becomes tempting, but very large global updates can destabilize some layers.
+
+LARS and LAMB introduce layerwise trust ratios. For a layer parameter vector $\boldsymbol{\theta}^{[\ell]}$ and update vector $\mathbf{u}^{[\ell]}$, the trust ratio is roughly
+
+$$
+r^{[\ell]}
+= \frac{\lVert \boldsymbol{\theta}^{[\ell]} \rVert_2}
+{\lVert \mathbf{u}^{[\ell]} \rVert_2 + \epsilon}.
+$$
+
+The update becomes
+
+$$
+\boldsymbol{\theta}_{t+1}^{[\ell]}
+= \boldsymbol{\theta}_t^{[\ell]}
+- \eta r^{[\ell]}\mathbf{u}^{[\ell]}.
+$$
+
+LAMB combines this layerwise scaling with Adam-style moments. It was introduced for large-batch BERT training, where layerwise update normalization helped maintain stable progress at huge batch sizes.
+
+### 5.2 Trust Ratio and Layerwise Update Scaling
+
+The trust ratio compares update norm to parameter norm. The dimensionless ratio
+
+$$
+\frac{\lVert \Delta \boldsymbol{\theta}^{[\ell]} \rVert_2}
+{\lVert \boldsymbol{\theta}^{[\ell]} \rVert_2}
+$$
+
+is often more informative than raw update norm. If this ratio is too high, the layer is being rewritten too aggressively. If it is too low, the layer is barely moving.
+
+**For AI:** Monitoring this ratio is useful in large-scale training. Many training failures look mysterious in loss curves but obvious in update-to-parameter norm diagnostics.
+
+### 5.3 Adafactor and Factored Second-Moment State
+
+Adam stores a second-moment tensor $v_t$ with the same shape as the parameter. For a matrix $W \in \mathbb{R}^{m \times n}$, that costs $mn$ state entries.
+
+Adafactor approximates the second-moment matrix using row and column statistics. Instead of storing all of $V \in \mathbb{R}^{m \times n}$, it stores
+
+$$
+\mathbf{r} \in \mathbb{R}^m,
+\qquad
+\mathbf{c} \in \mathbb{R}^n.
+$$
+
+A simple factored reconstruction has the flavor
+
+$$
+\widehat{V}_{ij}
+\approx \frac{r_i c_j}{\frac{1}{m}\sum_{k=1}^m r_k}.
+$$
+
+This reduces memory from $O(mn)$ to $O(m+n)$ for matrix-shaped parameters. That is a major difference for large models.
+
+### 5.4 Optimizer State Memory in Large Models
+
+For $N$ parameters, FP32 AdamW state costs approximately:
+
+$$
+2 \times 4N \text{ bytes}
+$$
+
+for $m_t$ and $v_t$. With FP32 master weights and gradients, the full training memory picture can be much larger. Distributed training systems therefore use sharding, offloading, lower-precision state, or memory-efficient optimizers.
+
+| Model scale | AdamW state only, FP32 | Practical implication |
+| ---: | ---: | --- |
+| $10^8$ params | about $0.8$ GB | easy on a modern accelerator |
+| $10^9$ params | about $8$ GB | optimizer state is a major budget item |
+| $10^{10}$ params | about $80$ GB | requires sharding/offload/factoring |
+| $10^{11}$ params | about $800$ GB | optimizer engineering dominates |
+
+### 5.5 When Layerwise Adaptation Helps or Hurts
+
+Layerwise adaptation helps when:
+
+- layers have very different parameter norms
+- large-batch training reduces gradient noise enough to permit bigger global steps
+- update-to-parameter ratios are unstable across layers
+- the model is large enough that layerwise scale mismatch matters
+
+It can hurt when:
+
+- parameter norms are tiny or not meaningful
+- normalization parameters or biases are treated like large matrices
+- the trust ratio masks bad gradients
+- hyperparameters are copied blindly from another workload
+
+The right lesson is not "LAMB is better than AdamW." It is "layerwise scale is another axis of adaptation, useful when scale mismatch is layer-level rather than coordinate-level."
+
+---
+
+## 6. Advanced Topics
+
+### 6.1 Adaptive Methods as Diagonal Natural-Gradient Approximations
+
+Natural gradient rescales updates by the inverse Fisher information matrix:
+
+$$
+\Delta \boldsymbol{\theta}
+= -\eta F(\boldsymbol{\theta})^{-1}\nabla \mathcal{L}(\boldsymbol{\theta}).
+$$
+
+If $F$ is approximated by a diagonal matrix whose entries are estimated by squared gradients, the update begins to resemble AdaGrad, RMSProp, or Adam without momentum. This is not an exact identity, but it is a useful mental bridge.
+
+The distinction matters. Natural gradient is invariant to certain reparameterizations because it uses the geometry of distributions. Adam uses coordinatewise gradient statistics. It is cheaper and easier, but less geometrically principled.
+
+### 6.2 Relationship to Curvature and Preconditioning
+
+Adaptive methods are sometimes described as curvature methods. That is partly true and partly misleading.
+
+True:
+
+- they rescale gradients like preconditioned methods
+- squared gradients can estimate diagonal Fisher-like quantities
+- they reduce some coordinatewise ill-conditioning
+
+Misleading:
+
+- they do not estimate the full Hessian
+- they ignore off-diagonal curvature
+- they can amplify noise if moment estimates are poor
+
+So Adam is best understood as a practical diagonal preconditioner with momentum, not as a cheap Newton method.
+
+### 6.3 Sign-Based and Low-Memory Optimizers
+
+Sign-based methods update using the sign of a gradient or momentum vector:
+
+$$
+\boldsymbol{\theta}_{t+1}
+= \boldsymbol{\theta}_t - \eta \operatorname{sign}(\mathbf{u}_t).
+$$
+
+Because Adam's normalized update can become sign-like in simple regimes, sign-based optimizers such as Lion are natural relatives. They may reduce state memory or improve certain workloads, but they should be treated as empirical optimizer proposals, not universal replacements.
+
+The 2026 practical stance is conservative: compare against strong AdamW baselines with the same schedule, compute budget, parameter groups, and regularization.
+
+### 6.4 Structured Preconditioners
+
+Diagonal preconditioners are cheap but limited. Structured methods such as Shampoo use matrix preconditioners for tensor dimensions. For a weight matrix $W$ and gradient $G$, a Shampoo-style update may use
+
+$$
+L^{-1/4} G R^{-1/4},
+$$
+
+where $L$ and $R$ approximate curvature along output and input dimensions.
+
+This can capture correlations that diagonal methods miss, but it costs more memory, computation, and systems complexity. The full treatment of curvature methods belongs to [Second-Order Methods](../03-Second-Order-Methods/notes.md); here Shampoo is a bridge showing how far optimizer design can move beyond coordinatewise adaptation.
+
+### 6.5 Stability Diagnostics
+
+A serious training run should log more than loss. Useful optimizer diagnostics include:
+
+$$
+\lVert \mathbf{g}_t \rVert_2,
+\qquad
+\lVert \Delta \boldsymbol{\theta}_t \rVert_2,
+\qquad
+\frac{\lVert \Delta \boldsymbol{\theta}_t \rVert_2}
+{\lVert \boldsymbol{\theta}_t \rVert_2},
+\qquad
+\eta_{t,i}^{\mathrm{eff}}.
+$$
+
+These reveal different failures:
+
+- exploding gradient norm: backward instability or loss scaling issue
+- tiny update norm: learning rate too small or denominators too large
+- huge update-to-parameter ratio: optimizer is rewriting weights
+- effective LR spikes: second-moment estimate too small or $\epsilon$ too small
+- layerwise imbalance: some modules learn while others stagnate
+
+---
+
+## 7. Applications in Machine Learning
+
+### 7.1 AdamW for Transformer Pretraining and Fine-Tuning
+
+AdamW is the default starting point for transformer training because it handles scale mismatch, sparse embeddings, noisy gradients, and decoupled weight decay. Typical parameter grouping excludes biases and normalization parameters from weight decay:
+
+```text
+decay:
+  large weight matrices
+
+no_decay:
+  bias terms
+  LayerNorm / RMSNorm scale parameters
+  sometimes embeddings depending on recipe
+```
+
+Fine-tuning usually uses much smaller learning rates than pretraining because pretrained weights already encode useful structure. The optimizer's job is to adapt without destroying.
+
+### 7.2 Sparse Embeddings and Recommendation Models
+
+Sparse embeddings are one of the cleanest use cases for adaptive methods. If a rare item appears once every million examples, it should not be forced to use the same historical step scale as a common item. AdaGrad's original motivation fits this setting well.
+
+For recommender systems, optimizer choice interacts with:
+
+- embedding frequency
+- delayed updates
+- distributed parameter servers
+- per-row accumulators
+- memory constraints
+
+### 7.3 Reinforcement Learning and Non-Stationary Objectives
+
+Reinforcement learning gradients are noisy and nonstationary. The data distribution changes as the policy changes, and gradient estimates often have high variance. Adam and RMSProp are common because their running statistics smooth unstable update directions.
+
+However, adaptivity can also hide instability. If the objective changes rapidly, old moment estimates can become stale. In RL, logging KL divergence, entropy, gradient norm, and update norm is often as important as optimizer choice.
+
+### 7.4 Large-Batch Training with LAMB
+
+Large-batch training tries to improve throughput by using more examples per optimizer step. But very large batches can destabilize the relationship between global learning rate, gradient noise, and layerwise update scale.
+
+LAMB addresses this by combining Adam-style updates with layerwise trust ratios. It was designed for BERT-scale large-batch training, where batch sizes can be much larger than ordinary single-node training.
+
+Use LAMB when large-batch scaling is the bottleneck and AdamW with careful scheduling is not enough. Do not use it just because it sounds more advanced.
+
+### 7.5 Practical Optimizer Selection Checklist
+
+| Workload | Strong starting point | Watch |
+| --- | --- | --- |
+| Transformer pretraining | AdamW | update norm, weight decay groups, schedule |
+| LLM fine-tuning | AdamW | catastrophic forgetting, LR too high |
+| Sparse embeddings | AdaGrad or Adam | rare-feature learning, state memory |
+| Vision classification | SGD + momentum or AdamW | generalization gap |
+| RL | Adam or RMSProp | nonstationarity and stale moments |
+| Large-batch BERT-style training | AdamW, then LAMB | trust ratio and schedule |
+| Memory-constrained large model | Adafactor or sharded AdamW | quality-memory trade-off |
+
+---
+
+## 8. Common Mistakes
+
+| # | Mistake | Why It's Wrong | Fix |
+| --- | --- | --- | --- |
+| 1 | "Adam chooses the learning rate for me." | Adam rescales coordinates but still has a global $\eta$ that strongly controls training. | Tune $\eta$ and use diagnostics for effective learning rates. |
+| 2 | "Adaptive optimizer means learning-rate schedule is unnecessary." | Internal adaptivity and external schedules solve different problems. | Use AdamW with warmup/decay when the workload calls for it. |
+| 3 | "Adam + $L_2$ is the same as AdamW." | Coupled $L_2$ enters the adaptive denominator; AdamW decouples decay. | Use AdamW for decoupled weight decay. |
+| 4 | "Weight decay should apply to every parameter." | Bias and normalization parameters often should not be decayed. | Use explicit parameter groups. |
+| 5 | "A smaller $\epsilon$ is always more accurate." | Tiny $\epsilon$ can create huge effective learning rates when $v_t$ is small. | Treat $\epsilon$ as a stability hyperparameter. |
+| 6 | "AMSGrad is always better because it has a proof." | Proof conditions do not guarantee better empirical deep-learning performance. | Use AMSGrad when stability demands it, not by default. |
+| 7 | "LAMB is a drop-in AdamW replacement." | LAMB changes layerwise update scaling and is mainly motivated by large batches. | Use it when trust ratios solve a real scaling issue. |
+| 8 | "Optimizer state memory is secondary." | AdamW state can exceed parameter memory at large scale. | Budget optimizer state early; consider sharding or Adafactor. |
+| 9 | "New optimizer beats AdamW in one paper, so switch." | Optimizer comparisons are highly schedule- and implementation-dependent. | Compare under equal compute, schedule, and tuning. |
+| 10 | "Diagonal adaptivity handles curvature." | It handles coordinatewise scale, not off-diagonal curvature. | Use structured preconditioners only when justified. |
+| 11 | "Effective learning rate is the same for all parameters." | The whole point of adaptive methods is coordinatewise effective LR. | Inspect distributions of effective LR and update norms. |
+| 12 | "Bias correction is a small implementation detail." | Early-step moments are biased toward zero without correction. | Keep bias correction unless reproducing a specific variant. |
+
+---
+
+## 9. Exercises
+
+1. **Exercise 1 (★): AdaGrad by Hand**
+   Given a sequence of scalar gradients, compute AdaGrad's accumulator, effective learning rate, and parameter updates.
+
+2. **Exercise 2 (★): RMSProp Forgetting**
+   Compare cumulative AdaGrad and exponentially weighted RMSProp on a gradient sequence whose scale changes halfway through.
+
+3. **Exercise 3 (★): Adam Bias Correction**
+   For a constant gradient, derive uncorrected and bias-corrected first and second moments.
+
+4. **Exercise 4 (★★): Effective Learning Rate Diagnostics**
+   Simulate multi-coordinate gradients and plot the effective learning rates under AdaGrad, RMSProp, and Adam.
+
+5. **Exercise 5 (★★): AdamW vs Coupled $L_2$**
+   Show numerically that coupled $L_2$ regularization and decoupled weight decay differ for Adam.
+
+6. **Exercise 6 (★★): LAMB Trust Ratio**
+   Compute layerwise trust ratios and explain how they change update magnitudes.
+
+7. **Exercise 7 (★★★): Adafactor Memory Savings**
+   Compare full Adam second-moment memory to factored Adafactor memory for matrix-shaped parameters.
+
+8. **Exercise 8 (★★★): Optimizer Diagnosis for a Failed Run**
+   Given synthetic logs of gradients, updates, parameters, and effective LRs, identify the likely failure mode and propose a fix.
+
+---
+
+## 10. Why This Matters for AI (2026 Perspective)
+
+| Concept | AI Impact |
+| --- | --- |
+| AdaGrad | Strong for sparse features, embeddings, and online learning |
+| RMSProp | Historical bridge from AdaGrad to Adam; useful in noisy/nonstationary settings |
+| Adam | Robust adaptive optimizer for stochastic objectives |
+| AdamW | Default baseline for transformers and LLM fine-tuning |
+| Bias correction | Stabilizes early optimizer steps |
+| Effective learning rate | Explains why adaptive methods still need global LR tuning |
+| Decoupled weight decay | Separates optimization step from regularization effect |
+| LAMB / LARS | Helps large-batch training by controlling layerwise update scale |
+| Adafactor | Reduces optimizer memory for large matrix-shaped parameters |
+| Optimizer diagnostics | Turns training failures into measurable signals |
+| Structured preconditioning | Active research direction beyond diagonal adaptation |
+
+The key 2026 lesson is that optimizer choice is now a systems decision as much as a mathematical one. AdamW may be mathematically simple compared with full curvature methods, but its memory footprint, mixed-precision behavior, parameter grouping, distributed state sharding, and interaction with schedules determine whether large model training is stable.
+
+At the same time, the field should be skeptical of optimizer hype. Many new optimizers look strong under one schedule, one model scale, or one benchmark. A serious comparison must control for learning-rate schedule, weight decay, parameter grouping, batch size, precision, and compute.
+
+---
+
+## 11. Conceptual Bridge
+
+Adaptive learning-rate methods sit at the center of the practical optimization stack. They inherit stochastic-gradient noise from [Stochastic Optimization](../05-Stochastic-Optimization/notes.md), respond to geometry studied in [Optimization Landscape](../06-Optimization-Landscape/notes.md), and borrow the preconditioning idea from [Second-Order Methods](../03-Second-Order-Methods/notes.md).
+
+They also point forward. [Regularization Methods](../08-Regularization-Methods/notes.md) explains why weight decay and other penalties affect generalization. [Hyperparameter Optimization](../09-Hyperparameter-Optimization/notes.md) studies how to tune optimizer hyperparameters systematically. [Learning Rate Schedules](../10-Learning-Rate-Schedules/notes.md) studies external time-varying schedules such as warmup, cosine decay, and WSD.
+
+The most important mental model is this: adaptive optimizers are not replacements for understanding learning rates. They are mechanisms for distributing one global learning-rate budget across coordinates, layers, and time.
+
+```text
+ADAPTIVE LEARNING RATE IN THE OPTIMIZATION CHAPTER
+════════════════════════════════════════════════════════════════════════
+
+  05 Stochastic Optimization
+       noisy gradient estimates
+              |
+              v
+  06 Optimization Landscape
+       geometry, sharpness, curvature
+              |
+              v
+  07 Adaptive Learning Rate
+       per-coordinate and layerwise update scaling
+              |
+      +-------+--------+
+      |                |
+      v                v
+  08 Regularization   10 Learning Rate Schedules
+      weight decay        warmup, cosine, WSD
+
+════════════════════════════════════════════════════════════════════════
+```
+
+## References
+
+1. Duchi, J., Hazan, E., and Singer, Y. (2011). "Adaptive Subgradient Methods for Online Learning and Stochastic Optimization." *Journal of Machine Learning Research*. https://jmlr.org/papers/v12/duchi11a.html
+2. Tieleman, T., and Hinton, G. (2012). "Lecture 6.5 - RMSProp." *Neural Networks for Machine Learning*.
+3. Kingma, D. P., and Ba, J. (2014). "Adam: A Method for Stochastic Optimization." https://arxiv.org/abs/1412.6980
+4. Reddi, S. J., Kale, S., and Kumar, S. (2018). "On the Convergence of Adam and Beyond." https://arxiv.org/abs/1904.09237
+5. Loshchilov, I., and Hutter, F. (2017). "Decoupled Weight Decay Regularization." https://arxiv.org/abs/1711.05101
+6. You, Y. et al. (2019). "Large Batch Optimization for Deep Learning: Training BERT in 76 minutes." https://arxiv.org/abs/1904.00962
+7. Shazeer, N., and Stern, M. (2018). "Adafactor: Adaptive Learning Rates with Sublinear Memory Cost." https://arxiv.org/abs/1804.04235
+8. Gupta, V., Koren, T., and Singer, Y. (2018). "Shampoo: Preconditioned Stochastic Tensor Optimization." https://arxiv.org/abs/1802.09568
+9. PyTorch Documentation. `torch.optim.AdamW`. https://docs.pytorch.org/docs/stable/generated/torch.optim.AdamW.html
+10. Optax Documentation. Optimizers API. https://optax.readthedocs.io/en/stable/api/optimizers.html

--- a/08-Optimization/07-Adaptive-Learning-Rate/theory.ipynb
+++ b/08-Optimization/07-Adaptive-Learning-Rate/theory.ipynb
@@ -1,0 +1,1282 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b266f424",
+   "metadata": {},
+   "source": [
+    "# Adaptive Learning Rate — Theory Notebook\n",
+    "\n",
+    "This notebook is the interactive companion to `notes.md`. It builds adaptive optimizers from scalar examples to multi-coordinate diagnostics using LaTeX-in-Markdown notation and executable NumPy code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2967cd29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import numpy.linalg as la\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    HAS_MPL = True\n",
+    "except ImportError:\n",
+    "    HAS_MPL = False\n",
+    "\n",
+    "try:\n",
+    "    import seaborn as sns\n",
+    "    HAS_SNS = True\n",
+    "except ImportError:\n",
+    "    HAS_SNS = False\n",
+    "\n",
+    "if HAS_MPL:\n",
+    "    if HAS_SNS:\n",
+    "        sns.set_theme(style=\"whitegrid\", palette=\"colorblind\")\n",
+    "    else:\n",
+    "        plt.style.use(\"seaborn-v0_8-whitegrid\")\n",
+    "    mpl.rcParams.update({\n",
+    "        \"figure.figsize\": (10, 6),\n",
+    "        \"figure.dpi\": 120,\n",
+    "        \"font.size\": 13,\n",
+    "        \"axes.titlesize\": 15,\n",
+    "        \"axes.labelsize\": 13,\n",
+    "        \"xtick.labelsize\": 11,\n",
+    "        \"ytick.labelsize\": 11,\n",
+    "        \"legend.fontsize\": 11,\n",
+    "        \"legend.framealpha\": 0.85,\n",
+    "        \"lines.linewidth\": 2.0,\n",
+    "        \"axes.spines.top\": False,\n",
+    "        \"axes.spines.right\": False,\n",
+    "        \"savefig.bbox\": \"tight\",\n",
+    "        \"savefig.dpi\": 150,\n",
+    "    })\n",
+    "\n",
+    "COLORS = {\n",
+    "    \"primary\": \"#0077BB\",\n",
+    "    \"secondary\": \"#EE7733\",\n",
+    "    \"tertiary\": \"#009988\",\n",
+    "    \"error\": \"#CC3311\",\n",
+    "    \"neutral\": \"#555555\",\n",
+    "    \"highlight\": \"#EE3377\",\n",
+    "}\n",
+    "\n",
+    "np.set_printoptions(precision=6, suppress=True)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "def check_close(name, got, expected, tol=1e-8):\n",
+    "    ok = np.allclose(got, expected, atol=tol, rtol=tol)\n",
+    "    print(f\"{'PASS' if ok else 'FAIL'} — {name}\")\n",
+    "    if not ok:\n",
+    "        print(\"  expected:\", expected)\n",
+    "        print(\"  got     :\", got)\n",
+    "    return ok\n",
+    "\n",
+    "def check_true(name, cond):\n",
+    "    print(f\"{'PASS' if cond else 'FAIL'} — {name}\")\n",
+    "    return cond\n",
+    "\n",
+    "def adagrad_update(theta, g, r, lr=0.1, eps=1e-8):\n",
+    "    r = r + g * g\n",
+    "    step = lr * g / (np.sqrt(r) + eps)\n",
+    "    return theta - step, r, step\n",
+    "\n",
+    "def rmsprop_update(theta, g, r, lr=0.1, rho=0.9, eps=1e-8):\n",
+    "    r = rho * r + (1 - rho) * (g * g)\n",
+    "    step = lr * g / (np.sqrt(r) + eps)\n",
+    "    return theta - step, r, step\n",
+    "\n",
+    "def adam_update(theta, g, m, v, t, lr=0.001, b1=0.9, b2=0.999, eps=1e-8):\n",
+    "    m = b1 * m + (1 - b1) * g\n",
+    "    v = b2 * v + (1 - b2) * (g * g)\n",
+    "    mhat = m / (1 - b1 ** t)\n",
+    "    vhat = v / (1 - b2 ** t)\n",
+    "    step = lr * mhat / (np.sqrt(vhat) + eps)\n",
+    "    return theta - step, m, v, step, mhat, vhat\n",
+    "\n",
+    "print(\"Setup complete.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0edc7c12",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1.1 One global learning rate fails\n",
+    "\n",
+    "Compare gradient descent on an ill-conditioned quadratic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6af561",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 1.1 One global learning rate fails ===\n",
+    "H = np.diag([1.0, 100.0])\n",
+    "theta = np.array([4.0, 4.0])\n",
+    "lr = 0.018\n",
+    "trajectory = [theta.copy()]\n",
+    "for _ in range(80):\n",
+    "    g = H @ theta\n",
+    "    theta = theta - lr * g\n",
+    "    trajectory.append(theta.copy())\n",
+    "trajectory = np.array(trajectory)\n",
+    "loss = 0.5 * np.sum((trajectory @ H) * trajectory, axis=1)\n",
+    "print(f\"initial loss: {loss[0]:.4f}\")\n",
+    "print(f\"final loss:   {loss[-1]:.4f}\")\n",
+    "check_true(\"loss decreases despite zigzag\", loss[-1] < loss[0])\n",
+    "if HAS_MPL:\n",
+    "    fig, ax = plt.subplots()\n",
+    "    ax.plot(trajectory[:, 0], label=\"$\\\\theta_1$\", color=COLORS[\"primary\"])\n",
+    "    ax.plot(trajectory[:, 1], label=\"$\\\\theta_2$\", color=COLORS[\"secondary\"])\n",
+    "    ax.set_title(\"One learning rate on an ill-conditioned quadratic\")\n",
+    "    ax.set_xlabel(\"Step\")\n",
+    "    ax.set_ylabel(\"Coordinate value\")\n",
+    "    ax.legend()\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef2753e9",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1.2 Diagonal preconditioning\n",
+    "\n",
+    "Rescale coordinates by a diagonal matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3399af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 1.2 Diagonal preconditioning ===\n",
+    "H = np.diag([1.0, 100.0])\n",
+    "theta_plain = np.array([4.0, 4.0])\n",
+    "theta_prec = np.array([4.0, 4.0])\n",
+    "P = np.diag([1.0, 0.01])\n",
+    "for _ in range(50):\n",
+    "    theta_plain -= 0.018 * (H @ theta_plain)\n",
+    "    theta_prec -= 0.2 * (P @ (H @ theta_prec))\n",
+    "loss_plain = 0.5 * theta_plain @ H @ theta_plain\n",
+    "loss_prec = 0.5 * theta_prec @ H @ theta_prec\n",
+    "print(f\"plain GD loss:         {loss_plain:.6f}\")\n",
+    "print(f\"preconditioned loss:   {loss_prec:.6f}\")\n",
+    "check_true(\"diagonal preconditioning improves this example\", loss_prec < loss_plain)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29d8d597",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1.3 Sparse gradients\n",
+    "\n",
+    "Show how rare coordinates keep larger AdaGrad steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09201e46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 1.3 Sparse gradients ===\n",
+    "grads = np.zeros((20, 3))\n",
+    "grads[:, 0] = 1.0\n",
+    "grads[::5, 1] = 1.0\n",
+    "grads[10, 2] = 1.0\n",
+    "r = np.zeros(3)\n",
+    "eff = []\n",
+    "for g in grads:\n",
+    "    r += g * g\n",
+    "    eff.append(0.1 / (np.sqrt(r) + 1e-8))\n",
+    "eff = np.array(eff)\n",
+    "print(\"final effective LR:\", eff[-1])\n",
+    "check_true(\"rare coordinate keeps largest effective LR\", eff[-1, 2] > eff[-1, 0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21e7c8d0",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1.4 Optimizer lineage\n",
+    "\n",
+    "Run the same gradient sequence through SGD, AdaGrad, RMSProp, and Adam."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "508dd1be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 1.4 Optimizer lineage ===\n",
+    "grads = np.array([1.0, 1.0, 1.0, 0.1, 0.1, 0.1])\n",
+    "theta_sgd = theta_ada = theta_rms = theta_adam = 1.0\n",
+    "r_ada = r_rms = m = v = 0.0\n",
+    "for t, g in enumerate(grads, 1):\n",
+    "    theta_sgd -= 0.1 * g\n",
+    "    theta_ada, r_ada, _ = adagrad_update(theta_ada, g, r_ada, lr=0.1)\n",
+    "    theta_rms, r_rms, _ = rmsprop_update(theta_rms, g, r_rms, lr=0.1)\n",
+    "    theta_adam, m, v, *_ = adam_update(theta_adam, g, m, v, t, lr=0.1)\n",
+    "print(f\"SGD theta:     {theta_sgd:.6f}\")\n",
+    "print(f\"AdaGrad theta: {theta_ada:.6f}\")\n",
+    "print(f\"RMSProp theta: {theta_rms:.6f}\")\n",
+    "print(f\"Adam theta:    {theta_adam:.6f}\")\n",
+    "check_true(\"methods produce different trajectories\", len({round(x, 4) for x in [theta_sgd, theta_ada, theta_rms, theta_adam]}) > 2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60dd763b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1.5 Transformer-style parameter groups\n",
+    "\n",
+    "Inspect different synthetic gradient scales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a0cc7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 1.5 Transformer-style parameter groups ===\n",
+    "groups = {\n",
+    "    \"embedding\": np.random.normal(0, 0.03, size=1000),\n",
+    "    \"attention\": np.random.normal(0, 0.10, size=1000),\n",
+    "    \"mlp\": np.random.normal(0, 0.20, size=1000),\n",
+    "    \"norm\": np.random.normal(0, 0.005, size=1000),\n",
+    "}\n",
+    "for name, g in groups.items():\n",
+    "    print(f\"{name:>10}: grad RMS={np.sqrt(np.mean(g*g)):.6f}\")\n",
+    "check_true(\"MLP gradients are largest in this synthetic example\", np.sqrt(np.mean(groups[\"mlp\"]**2)) > np.sqrt(np.mean(groups[\"norm\"]**2)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d814319",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2.1 Effective learning rate\n",
+    "\n",
+    "Compute coordinatewise effective learning rates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee0bd8dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 2.1 Effective learning rate ===\n",
+    "v = np.array([1e-4, 1e-2, 1.0, 100.0])\n",
+    "lr = 1e-3\n",
+    "eff = lr / (np.sqrt(v) + 1e-8)\n",
+    "print(\"v:\", v)\n",
+    "print(\"effective LR:\", eff)\n",
+    "check_true(\"larger second moment gives smaller effective LR\", np.all(np.diff(eff) < 0))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26c0407a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2.2 Second moments\n",
+    "\n",
+    "Compare cumulative and exponential squared-gradient statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b995b09f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 2.2 Second moments ===\n",
+    "g = np.r_[np.ones(8), 5*np.ones(8)]\n",
+    "cumulative = np.cumsum(g*g)\n",
+    "ema = []\n",
+    "r = 0.0\n",
+    "for x in g:\n",
+    "    r = 0.9 * r + 0.1 * x * x\n",
+    "    ema.append(r)\n",
+    "print(f\"cumulative final: {cumulative[-1]:.3f}\")\n",
+    "print(f\"EMA final:        {ema[-1]:.3f}\")\n",
+    "check_true(\"EMA adapts without growing unbounded\", ema[-1] < cumulative[-1])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8ff6272",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2.3 Preconditioner matrix\n",
+    "\n",
+    "Build and apply a diagonal preconditioner."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed5261fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 2.3 Preconditioner matrix ===\n",
+    "g = np.array([10.0, 1.0, 0.1])\n",
+    "v = g * g\n",
+    "P = np.diag(1 / (np.sqrt(v) + 1e-8))\n",
+    "u = P @ g\n",
+    "print(\"raw gradient:\", g)\n",
+    "print(\"preconditioned:\", u)\n",
+    "check_close(\"absolute preconditioned components are one\", np.abs(u), np.ones_like(u), tol=1e-6)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8aad2c8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2.4 Bias correction\n",
+    "\n",
+    "Verify Adam correction for constant gradients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d538d7e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 2.4 Bias correction ===\n",
+    "g = 3.0\n",
+    "b1 = 0.9\n",
+    "m = 0.0\n",
+    "for t in range(1, 6):\n",
+    "    m = b1 * m + (1 - b1) * g\n",
+    "    mhat = m / (1 - b1**t)\n",
+    "    print(f\"t={t}, m={m:.6f}, mhat={mhat:.6f}\")\n",
+    "check_close(\"bias-corrected moment recovers constant gradient\", mhat, g)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6f5c83",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2.5 State memory\n",
+    "\n",
+    "Estimate optimizer memory by parameter count."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "900d7203",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 2.5 State memory ===\n",
+    "params = np.array([1e6, 1e8, 1e9, 1e10])\n",
+    "adam_state_gb = 2 * 4 * params / 1e9\n",
+    "for n, gb in zip(params, adam_state_gb):\n",
+    "    print(f\"{n:>10.0f} params -> Adam state {gb:8.2f} GB\")\n",
+    "check_close(\"1B params Adam state\", adam_state_gb[2], 8.0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6d0999",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3.1 AdaGrad sparse behavior\n",
+    "\n",
+    "Rare coordinates retain step size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7da662a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 3.1 AdaGrad sparse behavior ===\n",
+    "grads = np.array([[1, 0, 0], [1, 0, 0], [1, 1, 0], [1, 0, 0], [1, 0, 1]], dtype=float)\n",
+    "r = np.zeros(3)\n",
+    "for t, g in enumerate(grads, 1):\n",
+    "    r += g*g\n",
+    "    print(f\"t={t}, accumulator={r}, eff_lr={0.1/(np.sqrt(r)+1e-8)}\")\n",
+    "check_true(\"rare third coordinate has largest effective LR\", (0.1/(np.sqrt(r)+1e-8))[2] > (0.1/(np.sqrt(r)+1e-8))[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b2fcafc",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3.2 AdaGrad diminishing steps\n",
+    "\n",
+    "Persistent gradients shrink effective LR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afcf07f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 3.2 AdaGrad diminishing steps ===\n",
+    "r = 0.0\n",
+    "steps = []\n",
+    "for _ in range(100):\n",
+    "    r += 1.0\n",
+    "    steps.append(0.1 / np.sqrt(r))\n",
+    "print(f\"first effective LR: {steps[0]:.6f}\")\n",
+    "print(f\"last effective LR:  {steps[-1]:.6f}\")\n",
+    "check_true(\"AdaGrad effective LR diminishes\", steps[-1] < steps[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "880ebfcb",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3.3 RMSProp forgetting\n",
+    "\n",
+    "A gradient scale shift is tracked with finite memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb18672e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 3.3 RMSProp forgetting ===\n",
+    "g = np.r_[np.ones(20), 10*np.ones(20), np.ones(20)]\n",
+    "r = 0.0\n",
+    "track = []\n",
+    "for x in g:\n",
+    "    r = 0.9*r + 0.1*x*x\n",
+    "    track.append(r)\n",
+    "print(f\"before spike: {track[19]:.3f}, after spike: {track[39]:.3f}, after recovery: {track[-1]:.3f}\")\n",
+    "check_true(\"RMSProp forgets old spike partly\", track[-1] < track[39])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88deb660",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3.4 Epsilon sensitivity\n",
+    "\n",
+    "Observe maximum effective LR as epsilon changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31bb9235",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 3.4 Epsilon sensitivity ===\n",
+    "v = 1e-12\n",
+    "for eps in [1e-8, 1e-6, 1e-4, 1e-2]:\n",
+    "    eff = 1e-3 / (np.sqrt(v) + eps)\n",
+    "    print(f\"epsilon={eps:g}, effective LR={eff:.6f}\")\n",
+    "check_true(\"larger epsilon caps effective LR\", 1e-3/(np.sqrt(v)+1e-2) < 1e-3/(np.sqrt(v)+1e-8))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a529303b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3.5 AdaDelta intuition\n",
+    "\n",
+    "Track gradient and update RMS values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b701878",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 3.5 AdaDelta intuition ===\n",
+    "g2 = 0.0\n",
+    "u2 = 0.0\n",
+    "rho = 0.95\n",
+    "for t in range(1, 6):\n",
+    "    g = 1.0 / t\n",
+    "    g2 = rho*g2 + (1-rho)*g*g\n",
+    "    update = -np.sqrt(u2 + 1e-6) / np.sqrt(g2 + 1e-6) * g\n",
+    "    u2 = rho*u2 + (1-rho)*update*update\n",
+    "    print(f\"t={t}, grad_rms={np.sqrt(g2):.6f}, update={update:.6f}, update_rms={np.sqrt(u2):.6f}\")\n",
+    "check_true(\"AdaDelta-style update is finite\", np.isfinite(update))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5262509",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4.1 Adam components\n",
+    "\n",
+    "Separate momentum and second-moment normalization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69a7343b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 4.1 Adam components ===\n",
+    "theta = 1.0\n",
+    "m = 0.0\n",
+    "v = 0.0\n",
+    "for t, g in enumerate([2.0, 2.0, 2.0], 1):\n",
+    "    theta, m, v, step, mhat, vhat = adam_update(theta, g, m, v, t, lr=0.1)\n",
+    "    print(f\"t={t}, mhat={mhat:.6f}, vhat={vhat:.6f}, step={step:.6f}, theta={theta:.6f}\")\n",
+    "check_true(\"Adam moved parameter downward\", theta < 1.0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "435bcb96",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4.2 Bias correction curves\n",
+    "\n",
+    "Plot correction factors over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a5f1ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 4.2 Bias correction curves ===\n",
+    "t = np.arange(1, 51)\n",
+    "c1 = 1 - 0.9**t\n",
+    "c2 = 1 - 0.999**t\n",
+    "print(f\"first c1={c1[0]:.6f}, c2={c2[0]:.6f}\")\n",
+    "print(f\"step 50 c1={c1[-1]:.6f}, c2={c2[-1]:.6f}\")\n",
+    "check_true(\"second moment correction grows slowly\", c2[-1] < c1[-1])\n",
+    "if HAS_MPL:\n",
+    "    fig, ax = plt.subplots()\n",
+    "    ax.plot(t, c1, label=\"$1-\\\\beta_1^t$\", color=COLORS[\"primary\"])\n",
+    "    ax.plot(t, c2, label=\"$1-\\\\beta_2^t$\", color=COLORS[\"secondary\"])\n",
+    "    ax.set_title(\"Adam bias-correction factors\")\n",
+    "    ax.set_xlabel(\"Step $t$\")\n",
+    "    ax.set_ylabel(\"Correction denominator\")\n",
+    "    ax.legend()\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef1d12c3",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4.3 Adam sign-like regime\n",
+    "\n",
+    "Constant gradients produce normalized updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cee8e61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 4.3 Adam sign-like regime ===\n",
+    "for g in [0.01, 1.0, 100.0]:\n",
+    "    step = 0.001 * g / (np.sqrt(g*g) + 1e-8)\n",
+    "    print(f\"g={g:8.3g}, normalized Adam-like step={step:.6f}\")\n",
+    "check_close(\"large and small positive gradients normalize similarly\", 0.001*0.01/(0.01+1e-8), 0.001*100/(100+1e-8), tol=1e-6)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0765d2bd",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4.4 AMSGrad maximum\n",
+    "\n",
+    "Keep nondecreasing denominators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cbd2cd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 4.4 AMSGrad maximum ===\n",
+    "vhat = np.array([4.0, 1.0, 9.0, 2.0, 3.0])\n",
+    "vmax = np.maximum.accumulate(vhat)\n",
+    "print(\"vhat: \", vhat)\n",
+    "print(\"vmax: \", vmax)\n",
+    "check_true(\"AMSGrad denominator is nondecreasing\", np.all(np.diff(vmax) >= 0))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0aa124d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4.5 AdamW versus L2\n",
+    "\n",
+    "Show coupled and decoupled decay differ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a9c05e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 4.5 AdamW versus L2 ===\n",
+    "theta = np.array([1.0, 10.0])\n",
+    "g = np.array([0.1, 0.1])\n",
+    "v = np.array([1e-4, 1.0])\n",
+    "lr = 0.01\n",
+    "wd = 0.1\n",
+    "coupled = theta - lr * (g + wd*theta) / (np.sqrt(v) + 1e-8)\n",
+    "decoupled = (1 - lr*wd) * theta - lr * g / (np.sqrt(v) + 1e-8)\n",
+    "print(\"coupled Adam-style L2:\", coupled)\n",
+    "print(\"decoupled AdamW:      \", decoupled)\n",
+    "check_true(\"coupled and decoupled decay differ\", not np.allclose(coupled, decoupled))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2755776b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5.1 LARS and LAMB\n",
+    "\n",
+    "Compute trust ratios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b6f50c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 5.1 LARS and LAMB ===\n",
+    "theta = np.array([3.0, 4.0])\n",
+    "u = np.array([0.06, 0.08])\n",
+    "trust = la.norm(theta) / (la.norm(u) + 1e-8)\n",
+    "print(f\"parameter norm: {la.norm(theta):.6f}\")\n",
+    "print(f\"update norm:    {la.norm(u):.6f}\")\n",
+    "print(f\"trust ratio:    {trust:.6f}\")\n",
+    "check_close(\"trust ratio\", trust, 50.0, tol=1e-5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d2b013a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5.2 Layerwise scaling\n",
+    "\n",
+    "Compare update-to-parameter ratios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaff432a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 5.2 Layerwise scaling ===\n",
+    "param_norms = np.array([10.0, 1.0, 0.1])\n",
+    "update_norms = np.array([1.0, 1.0, 1.0])\n",
+    "trust = param_norms / (update_norms + 1e-8)\n",
+    "print(\"trust ratios:\", trust)\n",
+    "check_true(\"small-parameter layer gets smallest trust ratio\", trust[-1] < trust[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1899d6b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5.3 Adafactor factoring\n",
+    "\n",
+    "Approximate a second-moment matrix from row and column stats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79ebb8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 5.3 Adafactor factoring ===\n",
+    "V = np.abs(np.random.lognormal(mean=0.0, sigma=0.6, size=(4, 6)))\n",
+    "r = V.mean(axis=1)\n",
+    "c = V.mean(axis=0)\n",
+    "Vhat = np.outer(r, c) / r.mean()\n",
+    "rel_err = la.norm(Vhat - V) / la.norm(V)\n",
+    "print(f\"full entries: {V.size}, factored entries: {len(r)+len(c)}\")\n",
+    "print(f\"relative reconstruction error: {rel_err:.6f}\")\n",
+    "check_true(\"factored state uses fewer entries\", len(r)+len(c) < V.size)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe974cca",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5.4 State memory at scale\n",
+    "\n",
+    "Plot memory costs for AdamW and Adafactor-style factoring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb46053f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 5.4 State memory at scale ===\n",
+    "params = np.logspace(6, 11, 6)\n",
+    "adam_gb = 2 * 4 * params / 1e9\n",
+    "for n, gb in zip(params, adam_gb):\n",
+    "    print(f\"{n:>12.0f} params -> AdamW state {gb:8.2f} GB\")\n",
+    "check_true(\"100B parameter Adam state is enormous\", adam_gb[-1] > 500)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb58936",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5.5 When layerwise scaling hurts\n",
+    "\n",
+    "Tiny parameter norms can create unstable trust ratios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e021ee94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 5.5 When layerwise scaling hurts ===\n",
+    "param_norm = 1e-6\n",
+    "update_norm = 1e-2\n",
+    "trust = param_norm / (update_norm + 1e-8)\n",
+    "print(f\"tiny layer trust ratio: {trust:.8f}\")\n",
+    "check_true(\"trust ratio can nearly freeze tiny-norm layers\", trust < 1e-3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "832c0d03",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6.1 Diagonal natural-gradient bridge\n",
+    "\n",
+    "Compare diagonal Fisher-style scaling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9358f47b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 6.1 Diagonal natural-gradient bridge ===\n",
+    "g = np.array([2.0, 0.5])\n",
+    "diag_fisher = np.array([4.0, 0.25])\n",
+    "nat_diag_step = g / (diag_fisher + 1e-8)\n",
+    "adam_like_step = g / (np.sqrt(diag_fisher) + 1e-8)\n",
+    "print(\"diagonal Fisher inverse step:\", nat_diag_step)\n",
+    "print(\"Adam-like inverse-root step: \", adam_like_step)\n",
+    "check_true(\"both rescale by geometry but differently\", not np.allclose(nat_diag_step, adam_like_step))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de8cb619",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6.2 Curvature limits\n",
+    "\n",
+    "Show diagonal scaling cannot remove rotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90da1e30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 6.2 Curvature limits ===\n",
+    "angle = np.pi / 4\n",
+    "Q = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])\n",
+    "H = Q @ np.diag([1.0, 100.0]) @ Q.T\n",
+    "diag_precond = np.diag(1 / np.diag(H))\n",
+    "residual = diag_precond @ H\n",
+    "print(\"preconditioned Hessian:\")\n",
+    "print(residual)\n",
+    "print(f\"off-diagonal magnitude: {abs(residual[0,1]):.6f}\")\n",
+    "check_true(\"diagonal scaling leaves off-diagonal coupling\", abs(residual[0,1]) > 0.1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f30ba725",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6.3 Sign-based updates\n",
+    "\n",
+    "Compare Adam-like normalized update to sign update."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3953dacd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 6.3 Sign-based updates ===\n",
+    "g = np.array([-10.0, -0.1, 0.2, 5.0])\n",
+    "adam_like = g / (np.sqrt(g*g) + 1e-8)\n",
+    "sign_update = np.sign(g)\n",
+    "print(\"Adam-like normalized:\", adam_like)\n",
+    "print(\"sign update:         \", sign_update)\n",
+    "check_close(\"normalization approaches sign\", adam_like, sign_update, tol=1e-6)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c12f0c7",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6.4 Structured preconditioner preview\n",
+    "\n",
+    "Apply a left/right matrix preconditioner."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47c15b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 6.4 Structured preconditioner preview ===\n",
+    "G = np.array([[3.0, 1.0], [1.0, 2.0]])\n",
+    "L_inv_quarter = np.diag([0.5, 1.0])\n",
+    "R_inv_quarter = np.diag([1.0, 0.25])\n",
+    "U = L_inv_quarter @ G @ R_inv_quarter\n",
+    "print(\"raw gradient matrix:\")\n",
+    "print(G)\n",
+    "print(\"structured preconditioned update:\")\n",
+    "print(U)\n",
+    "check_true(\"structured preconditioning changes matrix anisotropically\", not np.allclose(G, U))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5531d0c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6.5 Stability diagnostics\n",
+    "\n",
+    "Compute gradient, update, parameter, and ratio logs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86b63286",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 6.5 Stability diagnostics ===\n",
+    "theta = np.random.normal(size=100)\n",
+    "g = np.random.normal(scale=0.1, size=100)\n",
+    "v = np.square(g) + 1e-4\n",
+    "update = -1e-3 * g / (np.sqrt(v) + 1e-8)\n",
+    "ratio = la.norm(update) / la.norm(theta)\n",
+    "print(f\"grad norm:      {la.norm(g):.6f}\")\n",
+    "print(f\"update norm:    {la.norm(update):.6f}\")\n",
+    "print(f\"parameter norm: {la.norm(theta):.6f}\")\n",
+    "print(f\"update/param:   {ratio:.8f}\")\n",
+    "check_true(\"ratio is finite and positive\", np.isfinite(ratio) and ratio > 0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d96d71d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7.1 AdamW for transformers\n",
+    "\n",
+    "Synthetic parameter groups with no-decay rules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a55bb34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 7.1 AdamW for transformers ===\n",
+    "params = {\"q_proj.weight\": True, \"mlp.weight\": True, \"norm.weight\": False, \"bias\": False}\n",
+    "for name, decay in params.items():\n",
+    "    print(f\"{name:>14}: {'decay' if decay else 'no_decay'}\")\n",
+    "check_true(\"norm parameters are excluded from decay\", params[\"norm.weight\"] is False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "494acb58",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7.2 Sparse embeddings\n",
+    "\n",
+    "Per-row AdaGrad accumulators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "225335c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 7.2 Sparse embeddings ===\n",
+    "rows = 5\n",
+    "acc = np.zeros(rows)\n",
+    "accesses = [0, 0, 0, 1, 0, 2, 0, 3, 4, 0]\n",
+    "for row in accesses:\n",
+    "    acc[row] += 1.0\n",
+    "eff = 0.1 / (np.sqrt(acc) + 1e-8)\n",
+    "print(\"row accumulators:\", acc)\n",
+    "print(\"row effective LR:\", eff)\n",
+    "check_true(\"rare row has larger LR than common row\", eff[4] > eff[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05436c99",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7.3 Reinforcement learning noise\n",
+    "\n",
+    "EMA smoothing for nonstationary gradients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d47cc8ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 7.3 Reinforcement learning noise ===\n",
+    "signal = np.r_[np.ones(20), -np.ones(20)]\n",
+    "noise = np.random.normal(scale=2.0, size=40)\n",
+    "g = signal + noise\n",
+    "m = 0.0\n",
+    "ema = []\n",
+    "for x in g:\n",
+    "    m = 0.9*m + 0.1*x\n",
+    "    ema.append(m)\n",
+    "print(f\"raw gradient std: {np.std(g):.6f}\")\n",
+    "print(f\"EMA gradient std: {np.std(ema):.6f}\")\n",
+    "check_true(\"EMA smooths noisy gradients\", np.std(ema) < np.std(g))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ba0217d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7.4 Large-batch LAMB\n",
+    "\n",
+    "Trust ratio with batch-dependent update scale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43268aa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 7.4 Large-batch LAMB ===\n",
+    "theta_norm = 20.0\n",
+    "for update_norm in [0.5, 1.0, 2.0, 4.0]:\n",
+    "    trust = theta_norm / update_norm\n",
+    "    print(f\"update_norm={update_norm:.1f}, trust={trust:.2f}, scaled_update_norm={trust*update_norm:.2f}\")\n",
+    "check_close(\"trust ratio normalizes update to parameter norm\", theta_norm, 20.0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e1d83dc",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7.5 Optimizer checklist\n",
+    "\n",
+    "Score candidate optimizers for workloads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02bee68d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 7.5 Optimizer checklist ===\n",
+    "workloads = [\"transformer\", \"sparse_embeddings\", \"vision\", \"large_batch\"]\n",
+    "recommend = {\"transformer\": \"AdamW\", \"sparse_embeddings\": \"AdaGrad/Adam\", \"vision\": \"SGD+momentum or AdamW\", \"large_batch\": \"AdamW then LAMB\"}\n",
+    "for w in workloads:\n",
+    "    print(f\"{w:>18}: {recommend[w]}\")\n",
+    "check_true(\"transformer baseline is AdamW\", recommend[\"transformer\"] == \"AdamW\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b162af",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 8 Common mistakes\n",
+    "\n",
+    "Numerically demonstrate two common myths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18848b13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 8 Common mistakes ===\n",
+    "eta = 1e-3\n",
+    "v_small = 1e-12\n",
+    "eff_tiny_eps = eta / (np.sqrt(v_small) + 1e-8)\n",
+    "eff_large_eps = eta / (np.sqrt(v_small) + 1e-3)\n",
+    "print(f\"effective LR with tiny epsilon:  {eff_tiny_eps:.3f}\")\n",
+    "print(f\"effective LR with larger epsilon:{eff_large_eps:.3f}\")\n",
+    "check_true(\"epsilon is not just cosmetic\", eff_tiny_eps > 10 * eff_large_eps)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "118416b8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 9 Exercises preview\n",
+    "\n",
+    "List the practice arc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df385a72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 9 Exercises preview ===\n",
+    "topics = [\"AdaGrad\", \"RMSProp\", \"Adam bias correction\", \"AdamW\", \"LAMB\", \"Adafactor\", \"Diagnostics\"]\n",
+    "for i, topic in enumerate(topics, 1):\n",
+    "    print(f\"{i}. {topic}\")\n",
+    "check_true(\"practice arc includes AdamW\", \"AdamW\" in topics)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "597dc6e6",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 10 2026 AI perspective\n",
+    "\n",
+    "Compute optimizer state for model scales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d2bb0e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 10 2026 AI perspective ===\n",
+    "params_b = np.array([1, 7, 70, 405])\n",
+    "adam_state_gb = params_b * 1e9 * 8 / 1e9\n",
+    "for b, gb in zip(params_b, adam_state_gb):\n",
+    "    print(f\"{b:>4.0f}B params -> Adam state about {gb:>7.1f} GB\")\n",
+    "check_true(\"frontier-scale optimizer state dominates memory\", adam_state_gb[-1] > 1000)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30aa1a11",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 11 Conceptual bridge\n",
+    "\n",
+    "Summarize adaptation versus schedule and regularization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5638b50b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === 11 Conceptual bridge ===\n",
+    "print(\"11 Conceptual bridge\")\n",
+    "check_true(\"section executed\", True)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Add `08-Optimization/07-Adaptive-Learning-Rate/notes.md` in LaTeX-in-Markdown format.
- Add executable `theory.ipynb` covering adaptive optimizers, AdamW, LAMB, Adafactor, and diagnostics.
- Add `exercises.ipynb` with 8 graded exercises on adaptive optimizer mechanics and applications.

## Validation

- `git diff --cached --check`
- `MPLBACKEND=Agg .venv/bin/python` executed both Adaptive Learning Rate notebooks with `nbclient`.
